### PR TITLE
Remove leading slashes from rule tests

### DIFF
--- a/lib/test-jig.js
+++ b/lib/test-jig.js
@@ -31,6 +31,9 @@ TestJig.prototype.run = function() {
   var allResults = [];
   Object.keys(this.tests).forEach(function(path) {
 
+    // strip initial forward slash from objects
+    path = path.replace(/^\/+/g, '');
+
     var pathTests = this.tests[path];
 
     allResults = allResults


### PR DESCRIPTION
This fixes the case where the JSON testing framework treats paths with leading slashes as different from identical paths that lack the leading slash.

Closes #2, though in the future we probably need to do more robust path normalization.