### PR TITLE
Bug/fix up bin stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
+  - "4.1"

--- a/bin/targaryen
+++ b/bin/targaryen
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 
 'use strict';
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.4",
   "description": "Test Firebase security rules without connecting to Firebase.",
   "bin": {
-    "targaryen": "bin/targaryen.js"
+    "targaryen": "bin/targaryen"
   },
   "main": "index.js",
   "directories": {
@@ -14,7 +14,7 @@
     "url": "https://github.com/goldibex/targaryen"
   },
   "scripts": {
-    "test": "mocha -r test/setup.js test/spec/**/*.js && jasmine && node ./bin/targaryen.js --verbose test/integration/rules.json test/integration/tests.json"
+    "test": "mocha -r test/setup.js test/spec/**/*.js && jasmine && node ./bin/targaryen --verbose test/integration/rules.json test/integration/tests.json"
   },
   "author": "Harry Schmidt <me@goldibex.com>",
   "license": "ISC",


### PR DESCRIPTION
This PR adds a hashbang to the `bin/targaryen` program, sets the executable flag on it, and strips the `.js` from the file extension, all in the hopes of resolving #15.

I've added tests against Node 4.1 also just for completeness' sake.