### PR TITLE
Fixed the case when someone writes rule paths with a starting "/"

### DIFF
--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -20,6 +20,11 @@ function ruleError(rulePath, message) {
 
 }
 
+function pathSpliter(path)
+{
+  if(path[0] === '/') {path = path.substr(1);}
+  return path.split('/');
+}
 
 function makeNewDataSnap(path, newData) {
 
@@ -33,7 +38,7 @@ function makeNewDataSnap(path, newData) {
     var workObject = {};
     result = workObject;
 
-    path.split('/').forEach(function(pathPart, i, pathParts) {
+    pathSpliter(path).forEach(function(pathPart, i, pathParts) {
 
       if (pathParts.length - i === 1) {
         workObject[pathPart] = newData;
@@ -192,7 +197,7 @@ Ruleset.prototype.get = function(path, kind) {
 
     }
 
-  })(this._rules, [], path.split('/'));
+  })(this._rules, [], pathSpliter(path));
 
   return rules;
 
@@ -375,7 +380,7 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
 
     }
 
-  })([], path.split('/'), this._rules, {});
+  })([], pathSpliter(path), this._rules, {});
 
   result.allowed = result.writePermitted && result.validated;
 

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -155,7 +155,27 @@ describe('Ruleset', function() {
       expect(writeRules[3].rule).to.be.null;
 
     });
+    it('gets all the rules along a given node path even if path starts with "/"', function() {
 
+      var rules = getRuleset();
+
+      var readRules = rules.get('/foo/bar/baz/quux', 'read');
+      expect(readRules.length).to.equal(4);
+      expect(readRules[0].path).to.equal('/');
+      expect(readRules[1].path).to.equal('/foo');
+      expect(readRules[2].path).to.equal('/foo/bar');
+      expect(readRules[3].path).to.equal('/foo/bar/baz');
+
+      var writeRules = rules.get('/foo/bar/baz/quux', 'write');
+      expect(writeRules.length).to.equal(4);
+      expect(writeRules[0].path).to.equal('/');
+      expect(writeRules[0].rule).to.be.null;
+      expect(writeRules[1].path).to.equal('/foo');
+      expect(writeRules[2].path).to.equal('/foo/bar');
+      expect(writeRules[3].path).to.equal('/foo/bar/baz');
+      expect(writeRules[3].rule).to.be.null;
+
+    });
   });
 
   describe('#tryRead', function() {


### PR DESCRIPTION
 Fixed the case when someone writes rule paths with a starting "/" meaning root. Added a test to showcase this issue.