### PR TITLE
added a test for incorrect parent validation

### DIFF
--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -83,6 +83,27 @@ describe('the targaryen Jasmine plugin', function() {
 
   });
 
+  describe("deep write", function(){
+    beforeEach(function(){
+      targaryen.setFirebaseData(
+        { flats: { "221bbakerst": { landlady: 'Mrs Hudson' }  } }
+      )
+        targaryen.setFirebaseRules({
+          "rules": {
+            "flats": {
+              "$cid": {
+                ".validate": "newData.hasChildren(['landlady'])",
+                ".write": "true",
+                ".read": "true"
+              }
+            }
+          }
+        })
+    })  
+    it("should not check parent validations", function(){
+      expect({uid:'holmes'}).canWrite('/flats/221bbakerst/tenants/Holmes',{})
+    });
+  });
   xdescribe('using nested variables in path', function() {
 
     beforeEach(function() {


### PR DESCRIPTION
Firebase security does not check the parent ".validate" rules if only the child is updated, but targaryen does. This test demonstrates the issue.