### PR TITLE
Fixed .priority key overwritten when part of an Object

### DIFF
--- a/lib/rule-data-snapshot.js
+++ b/lib/rule-data-snapshot.js
@@ -49,7 +49,9 @@ RuleDataSnapshot.convert = function(data) {
       };
 
       Object.keys(node).forEach(function(key) {
-        newObj[key] = firebaseify(node[key]);
+        if (key != '.priority') {
+          newObj[key] = firebaseify(node[key]);
+        }
       });
 
       return newObj;

--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -167,4 +167,45 @@ describe('the targaryen Jasmine plugin', function() {
     });
 
   });
+
+  describe('when using priorities and nested data', function() {
+
+    beforeEach(function() {
+
+      targaryen.setFirebaseRules({
+        rules: {
+          somepath: {
+            ".write": true,
+            ".validate": "newData.hasChildren(['child1', 'child2']) && newData.getPriority() == 'prio'",
+            "child1": {
+              ".validate": "newData.val() == newData.parent().getPriority()"
+            }
+          }
+        }
+      });
+
+    });
+
+    it('it should validate priorities correctly', function() {
+
+      expect(targaryen.users.unauthenticated).canWrite("somepath", {
+        ".priority": "prio",
+        "child1": "prio",
+        "child2": "something"
+      });
+
+      expect(targaryen.users.unauthenticated).cannotWrite("somepath", {
+        ".priority": "prio",
+        "child1": "wrong-prio",
+        "child2": "something"
+      });
+
+      expect(targaryen.users.unauthenticated).cannotWrite("somepath", {
+        ".priority": "prio",
+        "child1": "prio"
+      });
+
+    });
+
+  });
 });

--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -168,44 +168,4 @@ describe('the targaryen Jasmine plugin', function() {
 
   });
 
-  describe('when using priorities and nested data', function() {
-
-    beforeEach(function() {
-
-      targaryen.setFirebaseRules({
-        rules: {
-          somepath: {
-            ".write": true,
-            ".validate": "newData.hasChildren(['child1', 'child2']) && newData.getPriority() == 'prio'",
-            "child1": {
-              ".validate": "newData.val() == newData.parent().getPriority()"
-            }
-          }
-        }
-      });
-
-    });
-
-    it('it should validate priorities correctly', function() {
-
-      expect(targaryen.users.unauthenticated).canWrite("somepath", {
-        ".priority": "prio",
-        "child1": "prio",
-        "child2": "something"
-      });
-
-      expect(targaryen.users.unauthenticated).cannotWrite("somepath", {
-        ".priority": "prio",
-        "child1": "wrong-prio",
-        "child2": "something"
-      });
-
-      expect(targaryen.users.unauthenticated).cannotWrite("somepath", {
-        ".priority": "prio",
-        "child1": "prio"
-      });
-
-    });
-
-  });
 });

--- a/test/spec/lib/rule-data-snapshot.js
+++ b/test/spec/lib/rule-data-snapshot.js
@@ -70,9 +70,22 @@ describe('RuleDataSnapshot', function() {
           '.priority': null
         }
       });
-
     });
 
+    it('transparently handles objects for which a priority is set in the root', function() {
+      expect(RuleDataSnapshot.convert({ '.priority': 100, foo: { '.value': true, '.priority': 5}, bar: 8 }))
+          .to.deep.equal({
+        '.priority': 100,
+        foo: {
+          '.value': true,
+          '.priority': 5
+        },
+        bar: {
+          '.value': 8,
+          '.priority': null
+        }
+      });
+    });
   });
 
   describe('#val', function() {


### PR DESCRIPTION
When testing with priorities, I encountered a problem where `.priority` keys were set to `null` when they were part of an Object with other fields. Turns out in the `firebaseify` function, all keys of an object are firebaseified, including the `.priority` key.