### PR TITLE
When deleting a node, .validate rules shouldn't apply.

### DIFF
--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -289,6 +289,11 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
 
     }
 
+    // If deleting a node, skipValidate
+    if (!state.newData.exists()) {
+      skipValidate = true;
+    }
+
     if (!skipValidate && rules.hasOwnProperty('.validate') && result.validated) {
 
       rule = rules['.validate'];

--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -168,4 +168,75 @@ describe('the targaryen Jasmine plugin', function() {
 
   });
 
+  describe("delete nodes", function(){
+    beforeEach(function(){
+      targaryen.setFirebaseData({
+        "test": {
+          "number": 42,
+          "bool": true
+        },
+        "canDelete": "test"
+      });
+      targaryen.setFirebaseRules({
+        "rules": {
+          "test": {
+            ".write": "true",
+            ".read": "true",
+            ".validate": "newData.hasChildren(['number', 'bool'])",
+            "number": {
+              ".validate": "newData.isNumber()"
+            },
+            "bool": {
+              ".validate": "newData.isBoolean()"
+            }
+          },
+          "canDelete": {
+            ".read": "true",
+            ".write": "true",
+            ".validate": "newData.isString()"
+          }
+        }
+      });
+    });
+
+    it("should not be able to delete /test/number", function(){
+      expect({uid:'anyone'}).cannotWrite('test/number', null);
+    });
+
+    it("should be able to delete /test", function(){
+      expect({uid:'anyone'}).canWrite('test', null);
+    });
+
+    it("should be able to delete /canDelete", function(){
+      expect({uid:'anyone'}).canWrite('canDelete', null);
+    });
+
+    it("should not be able to delete part of /test in a multi-update", function () {
+      expect({uid:'anyone'}).cannotWrite('/', {
+        "test": {
+          "bool": null
+        },
+        "canDelete": null
+      });
+    });
+
+    it("should be able to delete as part of a multi-path write", function () {
+      expect({uid:'anyone'}).canWrite('/', {
+        "test": {
+          "bool": false,
+          "number": 5
+        },
+        "canDelete": null
+      });
+    });
+
+    it("should be able to delete a whole object by nulling all children", function () {
+      expect({uid:'anyone'}).canWrite('test', {
+          "bool": null,
+          "number": null
+      });
+
+      pending("This doesn't work in the tests, but this works at least in the Javascrip SDK");
+    })
+  });
 });


### PR DESCRIPTION
The Firebase docs are not really clear about this, so I did some
tests on a real Firebase database with the Javascript SDK and
wrote corresponding tests in the test-suite.

I added a fix to skip validation rules when deleting a node.

Docs: "Additionally, the validate definitions are ignored when data is deleted (that is, when the new value being written is `null`)." (https://firebase.google.com/docs/database/security/securing-data#validating_data)