### PR TITLE
Add test method for patch operation

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -27,6 +27,16 @@ var plugin = function chaiTargaryen(chai, utils) {
     utils.flag(this, 'operationData', null);
   });
 
+  chai.Assertion.addChainableMethod('patch', function(data) {
+
+    utils.flag(this, 'operation', 'patch');
+    utils.flag(this, 'operationData', data);
+
+  }, function() {
+    utils.flag(this, 'operation', 'patch');
+    utils.flag(this, 'operationData', null);
+  });
+
   chai.Assertion.addMethod('path', function(path) {
 
     helpers.assertConfigured();
@@ -37,28 +47,41 @@ var plugin = function chaiTargaryen(chai, utils) {
       positivity = utils.flag(this, 'positivity'),
       result;
 
-    if (operationType === 'read') {
+    switch(operationType) {
+      case 'read':
+        result = rules.tryRead(path, root, this._obj);
 
-      result = rules.tryRead(path, root, this._obj);
+        if (positivity) {
+          chai.assert(result.allowed === true, helpers.unreadableError(result));
+        } else {
+          chai.assert(result.allowed === false, helpers.readableError(result));
+        }
 
-      if (positivity) {
-        chai.assert(result.allowed === true, helpers.unreadableError(result));
-      } else {
-        chai.assert(result.allowed === false, helpers.readableError(result));
-      }
+        return;
 
-    } else if (operationType === 'write') {
+      case 'write':
+        var newData = utils.flag(this, 'operationData');
 
-      var newData = utils.flag(this, 'operationData');
+        result = rules.tryWrite(path, root, newData, this._obj);
 
-      result = rules.tryWrite(path, root, newData, this._obj);
+        break;
 
-      if (positivity) {
-        chai.assert(result.allowed === true, helpers.unwritableError(result));
-      } else {
-        chai.assert(result.allowed === false, helpers.writableError(result));
-      }
+      case 'patch':
+        var newData = utils.flag(this, 'operationData');
 
+        result = rules.tryPatch(path, root, newData, this._obj);
+
+        break;
+
+      default:
+
+        return;
+    }
+
+    if (positivity) {
+      chai.assert(result.allowed === true, helpers.unwritableError(result));
+    } else {
+      chai.assert(result.allowed === false, helpers.writableError(result));
     }
 
   });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,18 +2,36 @@
 
 var RuleDataSnapshot = require('./rule-data-snapshot');
 
+function trimLeft(path) {
+  path = path || '';
+
+  return path.replace(/^\/+/, '');
+}
+
+function trimRight(path) {
+  path = path || '';
+
+  return path.replace(/\/+$/, '');
+}
+
+function trim(path) {
+  return trimLeft(trimRight(path));
+}
+
+exports.pathMerger = function(root, path) {
+  root = trim(root);
+  path = trimLeft(path);
+
+  return root + '/' + path;
+}
+
 exports.pathSplitter = function(path) {
-
-  if (path[0] === '/') {
-    path = path.substr(1);
-  }
-
-  return path.split('/');
+  return trimLeft(path).split('/');
 };
 
 exports.makeNewDataSnap = function(path, newData) {
 
-  path = path.replace(/^\/+/, '');
+  path = trimLeft(path);
   newData = RuleDataSnapshot.convert(newData)
 
   var result;

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -75,6 +75,39 @@ exports.matchers = {
       };
 
     }};
+  },
+  canPatch: function() {
+
+    return { compare: function(auth, path, newData) {
+
+      var root = helpers.getFirebaseData(),
+        rules = helpers.getFirebaseRules();
+
+      var result = rules.tryPatch(path, root, newData, auth);
+
+      return {
+        pass: result.allowed === true,
+        message: helpers.unwritableError(result)
+      };
+
+    }};
+
+  },
+  cannotPatch: function() {
+
+    return { compare: function(auth, path, newData) {
+
+      var root = helpers.getFirebaseData(),
+        rules = helpers.getFirebaseRules();
+
+      var result = rules.tryPatch(path, root, newData, auth);
+
+      return {
+        pass: result.allowed === false,
+        message: helpers.writableError(result)
+      };
+
+    }};
   }
 
 };

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -5,6 +5,7 @@ var extend = require('extend'),
   Rule = require('./parser/rule'),
   RuleDataSnapshot = require('./rule-data-snapshot'),
   pathSplitter = require('./helpers').pathSplitter,
+  pathMerger = require('./helpers').pathMerger,
   makeNewDataSnap = require('./helpers').makeNewDataSnap;
 
 var validRuleKinds = {
@@ -251,6 +252,50 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
     data: root.child(path).val(),
     newData: newDataRoot.child(path).val()
   };
+
+  return this._tryWrite(path, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
+};
+
+Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skipValidate, skipOnNoValue) {
+  var newDataRoot = root,
+      pathsToTest = [],
+      self = this;
+
+  Object.keys(newData).forEach(function(endPath){
+    var pathToNode = pathMerger(path, endPath)
+
+    newDataRoot = newDataRoot.merge(makeNewDataSnap(pathToNode, newData[endPath]));
+    pathsToTest.push(pathToNode);
+  });
+
+  return pathsToTest.map(function(pathToNode) {
+    var result = {
+      path: pathToNode,
+      type: 'patch',
+      info: '',
+      allowed: false,
+      auth: auth === undefined ? null : auth,
+      writePermitted: skipWrite || false,
+      validated: true,
+      data: root.child(pathToNode),
+      newData: newDataRoot.child(pathToNode).val()
+    };
+
+    return self._tryWrite(pathToNode, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
+  }).reduce(function(result, pathResult) {
+    result.path = path;
+    result.newData = newData;
+    result.info += pathResult.info;
+    result.allowed = result.allowed && pathResult.allowed;
+    result.writePermitted = result.writePermitted && pathResult.writePermitted;
+    result.validated = result.validated && pathResult.validated;
+
+    return result;
+  });
+};
+
+
+Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue) {
 
   // walk down the rules hierarchy -- to get the .write and .validate rules along here
   (function traverse(pathParts, remainingPath, rules, wildchildren) {

--- a/test/spec/lib/helpers.js
+++ b/test/spec/lib/helpers.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var helpers = require('../../../lib/helpers.js'),
+    RuleDataSnapshot = require('../../../lib/rule-data-snapshot');
+
+describe('helpers', function() {
+
+  describe('pathMerger', function() {
+
+    it('should merge path', function() {
+      expect(helpers.pathMerger('foo', 'bar/baz')).to.equal('foo/bar/baz');
+    });
+
+    it('should trim root path', function() {
+      expect(helpers.pathMerger('/foo/', 'bar/baz')).to.equal('foo/bar/baz');
+    });
+
+    it('should trim the beginning of the path', function() {
+      expect(helpers.pathMerger('foo', '/bar/baz')).to.equal('foo/bar/baz');
+    });
+
+  });
+
+  describe('pathSplitter', function() {
+
+    it('should split the path', function() {
+      expect(helpers.pathSplitter('foo/bar/baz')).to.eql(['foo', 'bar', 'baz']);
+    });
+
+    it('should trim the beginning of the path', function() {
+      expect(helpers.pathSplitter('/foo/bar/baz')).to.eql(['foo', 'bar', 'baz']);
+    });
+
+  });
+
+  describe('makeNewDataSnap', function() {
+
+    it('should create a snapshot for the path', function() {
+      var snapshot = helpers.makeNewDataSnap('foo/bar/baz', 1);
+
+      expect(snapshot).to.eql(new RuleDataSnapshot({
+        foo: {
+          bar: {
+            baz: {
+              '.value': 1,
+              '.priority': null
+            }
+          }
+        }
+      }));
+    });
+
+    it('should trim the begining of the path', function() {
+      var snapshot = helpers.makeNewDataSnap('/foo/bar/baz', 1);
+
+      expect(snapshot).to.eql(new RuleDataSnapshot({
+        foo: {
+          bar: {
+            baz: {
+              '.value': 1,
+              '.priority': null
+            }
+          }
+        }
+      }));
+    });
+
+  });
+
+});

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -226,4 +226,53 @@ describe('Ruleset', function() {
 
   });
 
+  describe('#tryPatch', function() {
+
+    var rules, root, auth;
+
+    beforeEach(function() {
+      rules = new Ruleset({
+        rules: {
+          '.read': false,
+          foo: {
+            '.read': 'auth !== null',
+            '.write': 'auth.id === 1',
+            '.validate': 'newData.hasChildren(["bar", "baz", "fooz"])',
+            bar: {
+              '.validate': 'data.exists() == false'
+            }
+          }
+        }
+      });
+      root = new RuleDataSnapshot({
+        foo: {
+          bar: {
+            '.value': true
+          },
+          baz: {
+            '.value': true
+          },
+          fooz: {
+            '.value': true
+          }
+        }
+      });
+      auth = {id: 1}
+    });
+
+    it('should allow validate write', function() {
+      var newData = {
+        'foo/baz': false,
+        'foo/fooz': false
+      };
+
+      expect(rules.tryPatch('/', root, newData, auth).allowed).to.be.true
+      expect(rules.tryPatch('/', root, newData, null).allowed).to.be.false
+
+      newData['foo/bar'] = false;
+      expect(rules.tryPatch('/', root, newData, auth).allowed).to.be.false
+    });
+
+  });
+
 });


### PR DESCRIPTION
Adds support for testing `update` operations, including [multi-location updates](https://firebase.googleblog.com/2015/09/introducing-multi-location-updates-and_86.html).

It will test each node using the same `data`/`newData` snapshot.

It includes a chai `patch` operator and jasmin `canPatch`/`cannotPatch` operators.