### PR TITLE
Fix initial timestamps

### DIFF
--- a/lib/rule-data-snapshot.js
+++ b/lib/rule-data-snapshot.js
@@ -1,7 +1,8 @@
 
 'use strict';
 
-var extend = require('extend');
+var extend = require('extend'),
+  initialCommitTime = new Date('Tue Dec 23 2014 18:35:40 GMT+0000 (GMT)').getTime();
 
 function RuleDataSnapshot(data, path) {
 
@@ -13,6 +14,10 @@ function RuleDataSnapshot(data, path) {
   this._data = data;
   this._path = path;
 
+}
+
+RuleDataSnapshot.now = function() {
+  return initialCommitTime;
 }
 
 RuleDataSnapshot.convert = function(data) {
@@ -34,7 +39,7 @@ RuleDataSnapshot.convert = function(data) {
       if (node['.sv'] === 'timestamp') {
 
         return {
-          '.value': Date.now(),
+          '.value': RuleDataSnapshot.now(),
           '.priority': node.hasOwnProperty('.priority') ? node['.priority'] : null
         };
 

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -173,7 +173,7 @@ Ruleset.prototype.tryRead = function(path, root, auth) {
 
   var state = {
     auth: auth === undefined ? null : auth,
-    now: Date.now(),
+    now: RuleDataSnapshot.now(),
     root: root,
     data: root.child(path)
   };
@@ -306,7 +306,7 @@ Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrit
 
     var state = extend({
       auth: result.auth,
-      now: Date.now(),
+      now: RuleDataSnapshot.now(),
       root: root,
       data: root.child(currentPath),
       newData: newDataRoot.child(currentPath)

--- a/test/spec/lib/rule-data-snapshot.js
+++ b/test/spec/lib/rule-data-snapshot.js
@@ -28,6 +28,19 @@ var root = new RuleDataSnapshot(rootObj);
 
 describe('RuleDataSnapshot', function() {
 
+  describe('now', function() {
+
+    it('should return a fixes date', function(done) {
+      var t1 = RuleDataSnapshot.now();
+
+      setTimeout(function() {
+        expect(t1).to.equal(RuleDataSnapshot.now());
+        done();
+      }, 10);
+    });
+
+  });
+
   describe('convert', function() {
 
     it('converts plain Javascript objects into Firebase data format', function() {
@@ -86,6 +99,16 @@ describe('RuleDataSnapshot', function() {
         }
       });
     });
+
+    it('should convert timestamp to a predictable date', function(done) {
+      var snapshot = RuleDataSnapshot.convert({ts: {'.sv': 'timestamp'}});
+
+      setTimeout(function() {
+        expect(snapshot.ts['.value']).to.equal(RuleDataSnapshot.now());
+        done();
+      }, 10);
+    });
+
   });
 
   describe('#val', function() {


### PR DESCRIPTION
The server timestamps created by `RuleDataSnapshot.convert(data)` and the rulesets `now` timestamp did not match.

They now both match to `RuleDataSnapshot.now()` (returns this project initial commit date).

Fix #29.