### PR TITLE
Fix initial timestamps (alternative)

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -17,24 +17,28 @@ var plugin = function chaiTargaryen(chai, utils) {
     utils.flag(this, 'operation', 'read');
   });
 
-  chai.Assertion.addChainableMethod('write', function(data) {
+  chai.Assertion.addChainableMethod('write', function(data, now) {
 
     utils.flag(this, 'operation', 'write');
     utils.flag(this, 'operationData', data);
+    utils.flag(this, 'operationTimestamp', now);
 
   }, function() {
     utils.flag(this, 'operation', 'write');
     utils.flag(this, 'operationData', null);
+    utils.flag(this, 'operationTimestamp', null);
   });
 
-  chai.Assertion.addChainableMethod('patch', function(data) {
+  chai.Assertion.addChainableMethod('patch', function(data, now) {
 
     utils.flag(this, 'operation', 'patch');
     utils.flag(this, 'operationData', data);
+    utils.flag(this, 'operationTimestamp', now);
 
   }, function() {
     utils.flag(this, 'operation', 'patch');
     utils.flag(this, 'operationData', null);
+    utils.flag(this, 'operationTimestamp', null);
   });
 
   chai.Assertion.addMethod('path', function(path) {
@@ -44,12 +48,13 @@ var plugin = function chaiTargaryen(chai, utils) {
     var root = helpers.getFirebaseData(),
       rules = helpers.getFirebaseRules(),
       operationType = utils.flag(this, 'operation'),
+      now = utils.flag(this, 'operationTimestamp'),
       positivity = utils.flag(this, 'positivity'),
       result;
 
     switch(operationType) {
       case 'read':
-        result = rules.tryRead(path, root, this._obj);
+        result = rules.tryRead(path, root, this._obj, now);
 
         if (positivity) {
           chai.assert(result.allowed === true, helpers.unreadableError(result));
@@ -62,14 +67,14 @@ var plugin = function chaiTargaryen(chai, utils) {
       case 'write':
         var newData = utils.flag(this, 'operationData');
 
-        result = rules.tryWrite(path, root, newData, this._obj);
+        result = rules.tryWrite(path, root, newData, this._obj, false, false, false, now);
 
         break;
 
       case 'patch':
         var newData = utils.flag(this, 'operationData');
 
-        result = rules.tryPatch(path, root, newData, this._obj);
+        result = rules.tryPatch(path, root, newData, this._obj, false, false, false, now);
 
         break;
 

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -17,6 +17,16 @@ var plugin = function chaiTargaryen(chai, utils) {
     utils.flag(this, 'operation', 'read');
   });
 
+  chai.Assertion.addChainableMethod('readAt', function(now) {
+
+    utils.flag(this, 'operation', 'read');
+    utils.flag(this, 'operationTimestamp', now);
+
+  }, function() {
+    utils.flag(this, 'operation', 'read');
+    utils.flag(this, 'operationTimestamp', null);
+  });
+
   chai.Assertion.addChainableMethod('write', function(data, now) {
 
     utils.flag(this, 'operation', 'write');

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -27,10 +27,10 @@ exports.pathSplitter = function(path) {
   return exports.trimLeft(path).split('/');
 };
 
-exports.makeNewDataSnap = function(path, newData) {
+exports.makeNewDataSnap = function() {
   var RuleDataSnapshot = require('./rule-data-snapshot');
 
   console.log('makeNewDataSnap is deprecated. Use RuleDataSnapshot.create instead.');
 
-  return RuleDataSnapshot.create(path, newData);
+  return RuleDataSnapshot.create.apply(null, arguments);
 };

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -11,12 +11,12 @@ exports.matchers = {
 
   canRead: function() {
 
-    return { compare: function(auth, path) {
+    return { compare: function(auth, path, now) {
 
       var root = helpers.getFirebaseData(),
         rules = helpers.getFirebaseRules();
 
-      var result = rules.tryRead(path, root, auth);
+      var result = rules.tryRead(path, root, auth, now);
 
       return {
         pass: result.allowed === true,
@@ -28,12 +28,12 @@ exports.matchers = {
   },
   cannotRead: function() {
 
-    return { compare: function(auth, path) {
+    return { compare: function(auth, path, now) {
 
       var root = helpers.getFirebaseData(),
         rules = helpers.getFirebaseRules();
 
-      var result = rules.tryRead(path, root, auth);
+      var result = rules.tryRead(path, root, auth, now);
 
       return {
         pass: result.allowed === false,
@@ -45,12 +45,12 @@ exports.matchers = {
   },
   canWrite: function() {
 
-    return { compare: function(auth, path, newData) {
+    return { compare: function(auth, path, newData, now) {
 
       var root = helpers.getFirebaseData(),
         rules = helpers.getFirebaseRules();
 
-      var result = rules.tryWrite(path, root, newData, auth);
+      var result = rules.tryWrite(path, root, newData, auth, false, false, false, now);
 
       return {
         pass: result.allowed === true,
@@ -62,12 +62,12 @@ exports.matchers = {
   },
   cannotWrite: function() {
 
-    return { compare: function(auth, path, newData) {
+    return { compare: function(auth, path, newData, now) {
 
       var root = helpers.getFirebaseData(),
         rules = helpers.getFirebaseRules();
 
-      var result = rules.tryWrite(path, root, newData, auth);
+      var result = rules.tryWrite(path, root, newData, auth, false, false, false, now);
 
       return {
         pass: result.allowed === false,
@@ -78,12 +78,12 @@ exports.matchers = {
   },
   canPatch: function() {
 
-    return { compare: function(auth, path, newData) {
+    return { compare: function(auth, path, newData, now) {
 
       var root = helpers.getFirebaseData(),
         rules = helpers.getFirebaseRules();
 
-      var result = rules.tryPatch(path, root, newData, auth);
+      var result = rules.tryPatch(path, root, newData, auth, false, false, false, now);
 
       return {
         pass: result.allowed === true,
@@ -95,12 +95,12 @@ exports.matchers = {
   },
   cannotPatch: function() {
 
-    return { compare: function(auth, path, newData) {
+    return { compare: function(auth, path, newData, now) {
 
       var root = helpers.getFirebaseData(),
         rules = helpers.getFirebaseRules();
 
-      var result = rules.tryPatch(path, root, newData, auth);
+      var result = rules.tryPatch(path, root, newData, auth, false, false, false, now);
 
       return {
         pass: result.allowed === false,

--- a/lib/rule-data-snapshot.js
+++ b/lib/rule-data-snapshot.js
@@ -12,7 +12,16 @@ function coerce(v) {
   return isEmptyObj(v) ? null : v;
 }
 
-function RuleDataSnapshot(data, path) {
+function RuleDataSnapshot(data, pathOrNow, path) {
+
+  var now = pathOrNow;
+
+  if (typeof now === 'string') {
+    path = pathOrNow;
+    now = Date.now();
+  } else if (isNaN(now)) {
+    now = Date.now();
+  }
 
   if (typeof path === 'string' && path.charAt(0) === '/') {
     // remove any leading slash from the snapshot, it screws us up downstream
@@ -20,19 +29,20 @@ function RuleDataSnapshot(data, path) {
   }
 
   this._data = data;
+  this._timestamp = now;
   this._path = path;
 
 }
 
-RuleDataSnapshot.create = function(path, newData) {
+RuleDataSnapshot.create = function(path, newData, now) {
   const empty = new RuleDataSnapshot();
 
-  return empty.set(path, newData);
+  return empty.set(path, newData, now);
 };
 
-RuleDataSnapshot.convert = function(data) {
+RuleDataSnapshot.convert = function(data, now) {
 
-  return (function firebaseify(node) {
+  return (function firebaseify(node, ts) {
 
     node = coerce(node);
 
@@ -51,7 +61,7 @@ RuleDataSnapshot.convert = function(data) {
       if (node['.sv'] === 'timestamp') {
 
         return {
-          '.value': Date.now(),
+          '.value': ts,
           '.priority': node.hasOwnProperty('.priority') ? node['.priority'] : null
         };
 
@@ -67,7 +77,7 @@ RuleDataSnapshot.convert = function(data) {
 
       Object.keys(node).forEach(function(key) {
         if (key != '.priority') {
-          newObj[key] = firebaseify(node[key]);
+          newObj[key] = firebaseify(node[key], ts);
         }
       });
 
@@ -75,7 +85,7 @@ RuleDataSnapshot.convert = function(data) {
 
     }
 
-  })(data);
+  })(data, now || Date.now());
 
 };
 
@@ -109,16 +119,17 @@ RuleDataSnapshot.prototype.merge = function(other) {
     return merge({'.priority': oldPriority}, newNode);
   });
 
-  return new RuleDataSnapshot(data);
+  return new RuleDataSnapshot(data, other._timestamp);
 }
 
-RuleDataSnapshot.prototype.set = function(path, newData) {
+RuleDataSnapshot.prototype.set = function(path, newData, now) {
 
+  now = now || Date.now();
   path = helpers.trim(path);
-  newData = RuleDataSnapshot.convert(newData)
+  newData = RuleDataSnapshot.convert(newData, now);
 
   if (path.length === 0) {
-    return new RuleDataSnapshot(newData);
+    return new RuleDataSnapshot(newData, now);
   }
 
   let data = merge({}, this._data);
@@ -144,7 +155,7 @@ RuleDataSnapshot.prototype.set = function(path, newData) {
     currentNode = currentNode[key];
   });
 
-  return new RuleDataSnapshot(data);
+  return new RuleDataSnapshot(data, now);
 }
 
 RuleDataSnapshot.prototype._getVal = function() {
@@ -232,7 +243,7 @@ RuleDataSnapshot.prototype.child = function(childPath) {
   } else {
     newPath = childPath;
   }
-  return new RuleDataSnapshot(this._data, newPath);
+  return new RuleDataSnapshot(this._data, this._timestamp, newPath);
 };
 
 
@@ -240,7 +251,7 @@ RuleDataSnapshot.prototype.parent = function() {
 
   if (this._path) {
     var parentPath = this._path.split('/').slice(0, -1).join('/');
-    return new RuleDataSnapshot(this._data, parentPath);
+    return new RuleDataSnapshot(this._data, this._timestamp, parentPath);
   } else {
     return null;
   }

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -167,11 +167,11 @@ Ruleset.prototype.get = function(path, kind) {
 
 };
 
-Ruleset.prototype.tryRead = function(path, root, auth) {
+Ruleset.prototype.tryRead = function(path, root, auth, now) {
 
   var state = {
     auth: auth === undefined ? null : auth,
-    now: Date.now(),
+    now: now || Date.now(),
     root: root,
     data: root.child(path)
   };
@@ -232,12 +232,14 @@ Ruleset.prototype.tryRead = function(path, root, auth) {
 };
 
 
-Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skipValidate, skipOnNoValue) {
+Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skipValidate, skipOnNoValue, now) {
 
   // write encompasses both the cascading write rules and the
   // non-cascading validate rules
 
-  var newDataRoot = root.set(path, newData);
+  now = now || Date.now();
+
+  var newDataRoot = root.set(path, newData, now);
 
   var result = {
     path: path,
@@ -254,15 +256,17 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
   return this._tryWrite(path, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
 };
 
-Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skipValidate, skipOnNoValue) {
+Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skipValidate, skipOnNoValue, now) {
   var newDataRoot = root,
       pathsToTest = [],
       results;
 
-  Object.keys(newData).forEach(function(endPath){
-    var pathToNode = pathMerger(path, endPath)
+  now = now || Date.now();
 
-    newDataRoot = newDataRoot.set(pathToNode, newData[endPath]);
+  Object.keys(newData).forEach(function(endPath){
+    var pathToNode = pathMerger(path, endPath);
+
+    newDataRoot = newDataRoot.set(pathToNode, newData[endPath], now);
     pathsToTest.push(pathToNode);
   });
 
@@ -320,7 +324,7 @@ Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrit
 
     var state = Object.assign({
       auth: result.auth,
-      now: Date.now(),
+      now: newDataRoot._timestamp,
       root: root,
       data: root.child(currentPath),
       newData: newDataRoot.child(currentPath)

--- a/lib/test-helpers.js
+++ b/lib/test-helpers.js
@@ -138,10 +138,11 @@ exports.assertConfigured = function() {
 
 };
 
-exports.setFirebaseData = function(data) {
+exports.setFirebaseData = function(data, now) {
+  now = now || Date.now();
 
   try {
-    root = new RuleDataSnapshot(RuleDataSnapshot.convert(data));
+    root = new RuleDataSnapshot(RuleDataSnapshot.convert(data, now), now);
   } catch(e) {
     throw new Error('Proposed Firebase data is not valid: ' + e.message);
   }

--- a/lib/test-jig.js
+++ b/lib/test-jig.js
@@ -5,10 +5,11 @@ var RuleDataSnapshot = require('./rule-data-snapshot'),
   Ruleset = require('./ruleset');
 
 
-function TestJig(rules, testData) {
+function TestJig(rules, testData, now) {
+  now = now || Date.now();
 
   this.ruleset = new Ruleset(rules);
-  this.root = new RuleDataSnapshot(RuleDataSnapshot.convert(testData.root));
+  this.root = new RuleDataSnapshot(RuleDataSnapshot.convert(testData.root, now), now);
   this.users = testData.users;
   this.tests = testData.tests;
 

--- a/test/spec/lib/helpers.js
+++ b/test/spec/lib/helpers.js
@@ -38,31 +38,38 @@ describe('helpers', function() {
     it('should create a snapshot for the path', function() {
       var snapshot = helpers.makeNewDataSnap('foo/bar/baz', 1);
 
-      expect(snapshot).to.eql(new RuleDataSnapshot({
+      expect(snapshot.val()).to.eql({
         foo: {
           bar: {
-            baz: {
-              '.value': 1,
-              '.priority': null
-            }
+            baz: 1
           }
         }
-      }));
+      });
     });
 
     it('should trim the begining of the path', function() {
       var snapshot = helpers.makeNewDataSnap('/foo/bar/baz', 1);
 
-      expect(snapshot).to.eql(new RuleDataSnapshot({
+      expect(snapshot.val()).to.eql({
         foo: {
           bar: {
-            baz: {
-              '.value': 1,
-              '.priority': null
-            }
+            baz: 1
           }
         }
-      }));
+      });
+    });
+
+    it('should convert timestamp server values', function() {
+      var now = 12345000,
+        snapshot = helpers.makeNewDataSnap('foo/bar/baz', {'.sv': 'timestamp'}, now);
+
+      expect(snapshot.val()).to.eql({
+        foo: {
+          bar: {
+            baz: now
+          }
+        }
+      });
     });
 
   });

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -45,6 +45,12 @@ function getRuleset() {
             '.validate': 'newData.parent().child("type").val() == "b" \n&& newData.parent().child("a").exists() == false'
           }
         }
+      },
+      timestamp: {
+        $foo: {
+          '.write': true,
+          '.validate': 'newData.val() == now'
+        }
       }
     }
   });
@@ -254,10 +260,34 @@ describe('Ruleset', function() {
 
   describe('#tryWrite', function() {
 
-    var rules;
+    var rules, _now;
 
     before(function() {
       rules = getRuleset();
+    });
+
+    beforeEach(function() {
+      _now = Date.now;
+
+      var now = 1000;
+
+      Date.now = function() {
+        return now++;
+      }
+    });
+
+    afterEach(function() {
+      Date.now = _now;
+    });
+
+    it('should match "now" with the server timestamp', function() {
+
+      var root = getRoot(),
+        newData = {'.sv': 'timestamp'},
+        noAuth = null;
+
+      expect(rules.tryWrite('timestamp/foo', root, newData, noAuth).allowed).to.be.true;
+
     });
 
     it('returns the result of attempting to write the given path with the given DB state and new data', function() {
@@ -305,12 +335,32 @@ describe('Ruleset', function() {
 
   describe('#tryPatch', function() {
 
-    var rules, root, auth;
+    var rules, root, auth, _now;
+
+    beforeEach(function() {
+      _now = Date.now;
+
+      var now = 1000;
+
+      Date.now = function() {
+        return now++;
+      }
+    });
+
+    afterEach(function() {
+      Date.now = _now;
+    });
 
     beforeEach(function() {
       rules = new Ruleset({
         rules: {
           '.read': false,
+          timestamps: {
+            $foo: {
+              '.write': true,
+              '.validate': 'newData.val() == now'
+            }
+          },
           foo: {
             '.read': 'auth !== null',
             '.write': 'auth.id === 1',
@@ -356,6 +406,19 @@ describe('Ruleset', function() {
         }
       });
       auth = {id: 1}
+    });
+
+    it('should match "now" with the server timestamp', function() {
+      var newData = {
+        'timestamps/foo': {'.sv': 'timestamp'},
+        'timestamps/bar': {'.sv': 'timestamp'},
+        'timestamps/baz': 12345000
+      };
+
+      expect(rules.tryPatch('/', root, newData, null).allowed).to.be.false;
+
+      delete newData['timestamps/baz'];
+      expect(rules.tryPatch('/', root, newData, null).allowed).to.be.true;
     });
 
     it('should allow validate write', function() {


### PR DESCRIPTION
The server timestamps of the data (read) or newData (write/patch) snapshot do not necessary match the rulesets “now” timestamp.

The tests are unstable, relying on the snapshot and ruleset state `now` variable being created in the same nanosecond.

This fix attaches the timestamp to the snapshot and uses it to evaluate the ruleset.

API changes (backward compatible):
- `targaryen.setFirebaseData(data[, now])`;
- jasmine matchers gain an optional `now` argument;
- chai `read`, `write` and `patch` methods gain an optional `now` argument;
- `targaryen/lib/rule-data-snapshot.RuleDataSnapshot(data[, now], path)`;
- `targaryen/lib/rule-data-snapshot.RuleDataSnapshot.convert(data[, now])`;
- `targaryen/lib/helpers.makeNewDataSnap(path, data[, now])`;
- `targayen/lib/ruleset.prototype.tryRead(path, root, auth[, now])`;
- `targayen/lib/ruleset.prototype.tryWrite(path, root, newData, auth[, skipWrite[, skipValidate[, skipOnNoValue[, now]]]])`;
- `targayen/lib/ruleset.prototype.tryPatch(path, root, newData, auth[, skipWrite[, skipValidate[, skipOnNoValue[, now]]]])`.

`now` default to the value returned by`Date.now()` if not provided.

Fix #29.