### PR TITLE
Treat empty objects as null

### DIFF
--- a/lib/rule-data-snapshot.js
+++ b/lib/rule-data-snapshot.js
@@ -4,11 +4,11 @@
 var merge = require('lodash.mergewith');
 
 function isEmptyObj (obj) {
-  return obj && (typeof obj == "object") && Object.keys(obj).length === 0 && obj.constructor === Object
+  return obj && typeof obj == 'object' && Object.keys(obj).length === 0 && obj.constructor === Object;
 }
 
 function coerce(v) {
-  return (isEmptyObj(v) ? null : v)
+  return isEmptyObj(v) ? null : v;
 }
 
 function RuleDataSnapshot(data, path) {

--- a/lib/rule-data-snapshot.js
+++ b/lib/rule-data-snapshot.js
@@ -3,6 +3,14 @@
 
 var merge = require('lodash.mergewith');
 
+function isEmptyObj (obj) {
+  return obj && (typeof obj == "object") && Object.keys(obj).length === 0 && obj.constructor === Object
+}
+
+function coerce(v) {
+  return (isEmptyObj(v) ? null : v)
+}
+
 function RuleDataSnapshot(data, path) {
 
   if (typeof path === 'string' && path.charAt(0) === '/') {
@@ -18,6 +26,8 @@ function RuleDataSnapshot(data, path) {
 RuleDataSnapshot.convert = function(data) {
 
   return (function firebaseify(node) {
+
+    node = coerce(node);
 
     if (typeof node !== 'object' || node === null) {
 

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -249,7 +249,9 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
     writePermitted: skipWrite || false,
     validated: true,
     data: root.child(path).val(),
-    newData: newDataRoot.child(path).val()
+    root: root,
+    newData: newDataRoot.child(path).val(),
+    newRoot: newDataRoot
   };
 
   return this._tryWrite(path, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
@@ -276,7 +278,7 @@ Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skip
       auth: auth === undefined ? null : auth,
       writePermitted: skipWrite || false,
       validated: true,
-      data: root.child(pathToNode),
+      data: root.child(pathToNode).val(),
       newData: newDataRoot.child(pathToNode).val()
     };
 
@@ -292,14 +294,15 @@ Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skip
       auth: auth === undefined ? null : auth,
       writePermitted: skipWrite || false,
       validated: true,
-      data: root.child(path),
-      newData: newDataRoot.child(path).val()
+      data: root.child(path).val(),
+      root: root,
+      newData: newDataRoot.child(path).val(),
+      newRoot: newDataRoot
     };
   }
 
-  return results.reduce(function(result, pathResult) {
+  results = results.reduce(function(result, pathResult) {
     result.path = path;
-    result.newData = newData;
     result.info += pathResult.info;
     result.allowed = result.allowed && pathResult.allowed;
     result.writePermitted = result.writePermitted && pathResult.writePermitted;
@@ -307,6 +310,10 @@ Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skip
 
     return result;
   });
+  results.newRoot = newDataRoot
+  results.newData = newDataRoot.child(path).val()
+  return results
+
 };
 
 

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -258,7 +258,7 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
 Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skipValidate, skipOnNoValue) {
   var newDataRoot = root,
       pathsToTest = [],
-      self = this;
+      results;
 
   Object.keys(newData).forEach(function(endPath){
     var pathToNode = pathMerger(path, endPath)
@@ -267,7 +267,7 @@ Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skip
     pathsToTest.push(pathToNode);
   });
 
-  return pathsToTest.map(function(pathToNode) {
+  results = pathsToTest.map(function(pathToNode) {
     var result = {
       path: pathToNode,
       type: 'patch',
@@ -280,8 +280,24 @@ Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skip
       newData: newDataRoot.child(pathToNode).val()
     };
 
-    return self._tryWrite(pathToNode, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
-  }).reduce(function(result, pathResult) {
+    return this._tryWrite(pathToNode, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
+  }, this);
+
+  if (results.length === 0) {
+    return {
+      path: path,
+      type: 'patch',
+      info: '',
+      allowed: true,
+      auth: auth === undefined ? null : auth,
+      writePermitted: skipWrite || false,
+      validated: true,
+      data: root.child(path),
+      newData: newDataRoot.child(path).val()
+    };
+  }
+
+  return results.reduce(function(result, pathResult) {
     result.path = path;
     result.newData = newData;
     result.info += pathResult.info;

--- a/test/spec/lib/rule-data-snapshot.js
+++ b/test/spec/lib/rule-data-snapshot.js
@@ -41,7 +41,7 @@ describe('RuleDataSnapshot', function() {
         '.priority': null
       });
 
-      expect(RuleDataSnapshot.convert({ foo: { bar: true, baz: true } }))
+      expect(RuleDataSnapshot.convert({ foo: { bar: true, baz: true, quxEmpty: {}, quxNull: null} }))
       .to.deep.equal({
         '.priority': null,
         foo: {
@@ -52,6 +52,14 @@ describe('RuleDataSnapshot', function() {
           },
           baz: {
             '.value': true,
+            '.priority': null
+          },
+          quxEmpty: {
+            '.value': null,
+            '.priority': null
+          },
+          quxNull: {
+            '.value': null,
             '.priority': null
           }
         }
@@ -99,6 +107,13 @@ describe('RuleDataSnapshot', function() {
       var newDataRoot = root.merge(patch);
 
       expect(newDataRoot.child('users/password:c7ec6752-45b3-404f-a2b9-7df07b78d28e').exists()).to.be.false;
+    });
+
+    it('treats empty object as null', function() {
+      var patch = new RuleDataSnapshot(RuleDataSnapshot.convert({users: {}}));
+      var newDataRoot = root.merge(patch);
+
+      expect(newDataRoot.child('users').exists()).to.be.false;
     });
 
     it('can override null', function() {

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -336,6 +336,13 @@ describe('Ruleset', function() {
       expect(rules.tryPatch('nested/one/two', root, {foo: 2}, auth).allowed).to.be.false;
     });
 
+    it('should handle empty patch', function() {
+      const result = rules.tryPatch('nested/one/one', root, {}, auth)
+
+      expect(result.allowed).to.be.true;
+      expect(result.newData).to.eql({foo: 1});
+    });
+
   });
 
 });

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -284,7 +284,17 @@ describe('Ruleset', function() {
       var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': 1, 'b': 2})),
         rules = new Ruleset({rules: {'.write': true}});
 
-      expect(rules.tryWrite('/a', root, {}, null).newRoot.val()).to.be.deep.equal({'b': 2});
+      expect(rules.tryWrite('/a', root, null, null).newRoot.val()).to.be.deep.equal({'b': 2});
+
+    })
+
+    it('should prune null keys deeply', function(){
+
+      var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': {'b': 2}})),
+          rules = new Ruleset({rules: {'.write': true}});
+
+      expect(rules.tryWrite('/a/b', root, null, null).newRoot.val()).to.be.null
+      expect(rules.tryWrite('/a/b', root, null, null).newRoot.exists()).to.be.false
 
     })
 

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -261,6 +261,33 @@ describe('Ruleset', function() {
       expect(rules.tryWrite('nested/one/one', root, {id: {'.value': 'two'}}, auth).allowed).to.be.false;
     });
 
+    it('should treat empty object as null', function(){
+
+      var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': 1, 'b': 2})),
+        rules = new Ruleset({rules: {'.write': true}});
+
+      expect(rules.tryWrite('/a', root, {}, null).newData).to.be.null;
+      expect(rules.tryWrite('/', root, {}, null).newData).to.be.null;
+
+    });
+
+    it('should replace value at target path', function(){
+      var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': 1, 'b': 2})),
+          rules = new Ruleset({rules: {'.write': true}});
+
+      expect(rules.tryWrite('/', root, {'c': 3}, null).newData).to.be.deep.equal({'c': 3});
+
+    });
+
+    it('should prune null keys', function(){
+
+      var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': 1, 'b': 2})),
+        rules = new Ruleset({rules: {'.write': true}});
+
+      expect(rules.tryWrite('/a', root, {}, null).newRoot.val()).to.be.deep.equal({'b': 2});
+
+    })
+
   });
 
   describe('#tryPatch', function() {
@@ -337,11 +364,41 @@ describe('Ruleset', function() {
     });
 
     it('should handle empty patch', function() {
-      const result = rules.tryPatch('nested/one/one', root, {}, auth)
+      var result = rules.tryPatch('nested/one/one', root, {}, auth)
 
       expect(result.allowed).to.be.true;
       expect(result.newData).to.eql({foo: 1});
+
+      var root2 = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': 1, 'b': 2})),
+          rules2 = new Ruleset({rules: {'.write': true}});
+
+      expect(rules2.tryPatch('/a', root2, {}, null).newRoot.val()).to.deep.equal({'a': 1, 'b': 2});
+      expect(rules2.tryPatch('/', root2, {'a': {}}, null).newRoot.child('a').val()).to.be.null;
+
     });
+
+    it('should merge one level deep', function(){
+
+      var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': 1, 'b': 2})),
+          rules = new Ruleset({rules: {'.write': true}});
+
+      expect(rules.tryPatch('/', root, {'c': 3}, null).newRoot.val()).to.deep.equal({'a': 1, 'b': 2, 'c': 3});
+
+    });
+
+    it('should replace values at target paths', function(){
+
+      var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'foo': {'a': 1, 'b': 2}})),
+          rules = new Ruleset({rules: {'.write': true}});
+
+      expect(rules.tryPatch('/', root, {'foo/c': 3}, null).newRoot.val()).to.deep.equal({'foo': {'a': 1, 'b': 2, 'c': 3}});
+      expect(rules.tryPatch('/', root, {'foo': {'c': 3}}, null).newRoot.val()).to.deep.equal({'foo': {'c': 3}});
+
+    })
+
+
+
+
 
   });
 


### PR DESCRIPTION
Updates Targaryen to treat empty objects the same as `null` (as Firebase does), with tests.