### PR TITLE
Type inference for addition operand

### DIFF
--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -229,6 +229,8 @@ Scope.prototype._inferBinaryExpression = function(node) {
       node.inferredType = right;
     } else if (node.right.type === 'CallExpression') {
       node.inferredType = left;
+    } else if (left || right) {
+      node.inferredType = left || right;
     } else {
       throw nodeError(node, '+ needs 2 operands of types number, string, or CallExpression, but got ' +
         left + ' and ' + right + ' instead.');

--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -231,10 +231,7 @@ Scope.prototype._inferBinaryExpression = function(node) {
       node.inferredType = left;
     } else if (left || right) {
       node.inferredType = left || right;
-    } else {
-      throw nodeError(node, '+ needs 2 operands of types number, string, or CallExpression, but got ' +
-        left + ' and ' + right + ' instead.');
-    }
+    } 
 
   } else if (binaryArithmeticOperatorTypes[node.operator]) {
 

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -25,7 +25,8 @@ var validRules = [
   'root.hasChildren([auth.uid])',
   'root.child("users").child(auth.uid).child($here).val().replace("x", $here) === "yyzzy"',
   'root.child("str").val().matches(/foo/)',
-  'root.child("users/"+auth.uid).exists()'
+  'root.child("users/"+auth.uid).exists()',
+  'root.child(auth.x+auth.y).exists()'
 ];
 var invalidRules = [
   'var foo = 8', // invalid syntax (no declarations allowed)

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -24,7 +24,8 @@ var validRules = [
   'root.hasChildren([$here])',
   'root.hasChildren([auth.uid])',
   'root.child("users").child(auth.uid).child($here).val().replace("x", $here) === "yyzzy"',
-  'root.child("str").val().matches(/foo/)'
+  'root.child("str").val().matches(/foo/)',
+  'root.child("users/"+auth.uid).exists()'
 ];
 var invalidRules = [
   'var foo = 8', // invalid syntax (no declarations allowed)


### PR DESCRIPTION
Removes the requirement that addition operand types are statically determinable. 

In the Firebase simulator, I verified behaviour with expressions of the form `'users/'+auth.uid` (always returns a string) and `auth.a+auth.b` (return type determined at runtime - tested with both number and string operands).