### PR TITLE
Standardize result data

### DIFF
--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -249,8 +249,10 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
     auth: auth === undefined ? null : auth,
     writePermitted: skipWrite || false,
     validated: true,
-    data: root.child(path).val(),
-    newData: newDataRoot.child(path).val()
+    data: root.child(path),
+    newData: newDataRoot.child(path),
+    root: root,
+    newRoot: newDataRoot
   };
 
   return this._tryWrite(path, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
@@ -259,7 +261,8 @@ Ruleset.prototype.tryWrite = function(path, root, newData, auth, skipWrite, skip
 Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skipValidate, skipOnNoValue, now) {
   var newDataRoot = root,
       pathsToTest = [],
-      results;
+      pathResults,
+      result;
 
   now = now || Date.now();
 
@@ -270,46 +273,50 @@ Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skip
     pathsToTest.push(pathToNode);
   });
 
-  results = pathsToTest.map(function(pathToNode) {
-    var result = {
+  pathResults = pathsToTest.map(function(pathToNode) {
+    var pathResult = {
       path: pathToNode,
       type: 'patch',
       info: '',
       allowed: false,
       auth: auth === undefined ? null : auth,
       writePermitted: skipWrite || false,
-      validated: true,
-      data: root.child(pathToNode),
-      newData: newDataRoot.child(pathToNode).val()
+      validated: true
     };
 
-    return this._tryWrite(pathToNode, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue);
+    return this._tryWrite(pathToNode, root, newDataRoot, pathResult, skipWrite, skipValidate, skipOnNoValue);
   }, this);
 
-  if (results.length === 0) {
-    return {
+  if (pathResults.length === 0) {
+    result = {
       path: path,
       type: 'patch',
       info: '',
       allowed: true,
       auth: auth === undefined ? null : auth,
       writePermitted: skipWrite || false,
-      validated: true,
-      data: root.child(path),
-      newData: newDataRoot.child(path).val()
+      validated: true
     };
+  } else {
+    result = pathResults.reduce(function(result, pathResult) {
+      result.path = path;
+      result.newData = newData;
+      result.info += pathResult.info;
+      result.allowed = result.allowed && pathResult.allowed;
+      result.writePermitted = result.writePermitted && pathResult.writePermitted;
+      result.validated = result.validated && pathResult.validated;
+
+      return result;
+    });
   }
 
-  return results.reduce(function(result, pathResult) {
-    result.path = path;
-    result.newData = newData;
-    result.info += pathResult.info;
-    result.allowed = result.allowed && pathResult.allowed;
-    result.writePermitted = result.writePermitted && pathResult.writePermitted;
-    result.validated = result.validated && pathResult.validated;
+  result.data = root.child(path);
+  result.newData = newDataRoot.child(path);
+  result.root = root;
+  result.newRoot = newDataRoot;
 
-    return result;
-  });
+  return result
+
 };
 
 

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -184,7 +184,9 @@ Ruleset.prototype.tryRead = function(path, root, auth, now) {
     auth: state.auth,
     type: 'read',
     info: '',
-    allowed: false
+    allowed: false,
+    data: state.data,
+    root: state.root
   };
 
   for (var i = 0; i < rules.length; i++) {

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -321,7 +321,7 @@ describe('Ruleset', function() {
         type: {'.value': 'b'},
         b: {'.value': 1}
       }, auth);
-      expect(result.newData).to.eql({type: 'b', b: 1});
+      expect(result.newData.val()).to.eql({type: 'b', b: 1});
       expect(result.allowed).to.be.true;
 
       result = rules.tryWrite('mixedType/first', root, {
@@ -443,7 +443,7 @@ describe('Ruleset', function() {
       const result = rules.tryPatch('nested/one/one', root, {}, auth)
 
       expect(result.allowed).to.be.true;
-      expect(result.newData).to.eql({foo: 1});
+      expect(result.newData.val()).to.eql({foo: 1});
     });
 
   });


### PR DESCRIPTION
tryRead, tryWrite, and tryPatch return data & root as snapshots (no need to run .val() on these).
tryWrite and tryPatch also return newData and newRoot.