### PR TITLE
Loosen inferring

### DIFF
--- a/lib/parser/rule.js
+++ b/lib/parser/rule.js
@@ -54,7 +54,7 @@ function Rule(ruleStr, wildchildren, isWrite) {
   scope.assertIndentifiersExist(this._ast);
 
   if (this._ast.expression.inferredType !== 'boolean') {
-    throw new Error('Expression does not evaluate to a boolean');
+    throw new Error('Expression must evaluate to a boolean.');
   }
 
 }

--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -5,7 +5,7 @@ var nodeError = require('./node-error');
 
 var rootTypes = {
 
-  auth: 'object',
+  auth: 'any',
   root: 'RuleDataSnapshot',
   data: 'RuleDataSnapshot',
   now: 'number'
@@ -48,7 +48,7 @@ var properties = {
     length: 'number'
   },
   RuleDataSnapshot: {
-    val: { name: 'val', args: [] },
+    val: { name: 'val', args: [], returnType: 'primitive'},
     child: { name: 'child', args: ['string'], returnType: 'RuleDataSnapshot' },
     parent: { name: 'parent', args: [], returnType: 'RuleDataSnapshot' },
     hasChild: { name: 'hasChild', args: ['string'], returnType: 'boolean' },
@@ -56,25 +56,33 @@ var properties = {
       name: 'hasChildren',
       args: function(scope, node) {
 
+        if (node.arguments.length === 0) {
+          return;
+        }
+
         if (node.arguments.length > 1) {
           throw nodeError(node, 'Too many arguments to hasChildren');
-        } else if (node.arguments.length === 1) {
+        }
 
-          var argument = node.arguments[0];
-          if (argument.type !== 'ArrayExpression') {
-            throw nodeError(node, 'hasChildren takes 1 argument: an array of strings');
-          } else if (argument.elements.length === 0) {
-            throw nodeError(node, 'hasChildren got an empty array, expected some strings in there');
-          } else {
+        var argument = node.arguments[0];
 
-            for (var i = 0; i < argument.elements.length; i++) {
+        if (argument.type !== 'ArrayExpression') {
+          throw nodeError(node, 'hasChildren takes 1 argument: an array of strings');
+        }
 
-              if (scope.inferType(argument.elements[i]) && argument.elements[i].inferredType !== 'string') {
-                throw nodeError(node, 'hasChildren got an array with a non-string value');
-              }
+        if (argument.elements.length === 0) {
+          throw nodeError(node, 'hasChildren got an empty array, expected some strings in there');
+        }
 
-            }
+        for (var i = 0; i < argument.elements.length; i++) {
+          let argType = scope.inferType(argument.elements[i]);
 
+          if (fuzzyType(argType)) {
+            continue;
+          }
+
+          if (argType !== 'string') {
+            throw nodeError(node, 'hasChildren got an array with a non-string value');
           }
 
         }
@@ -83,13 +91,23 @@ var properties = {
       returnType: 'boolean'
     },
     exists: { name: 'exists', args: [], returnType: 'boolean' },
-    getPriority: { name: 'getPriority', args: [] },
+    getPriority: { name: 'getPriority', args: [], returnType: 'any'},
     isNumber: { name: 'isNumber', args: [], returnType: 'boolean' },
     isString: { name: 'isString', args: [], returnType: 'boolean' },
     isBoolean: { name: 'isoolean', args: [], returnType: 'boolean' }
   }
 
 };
+
+const primitiveTypes = new Set(['string', 'number', 'boolean', 'primitive']);
+
+function isPrimitiveType(type) {
+  return primitiveTypes.has(type);
+}
+
+function fuzzyType(type) {
+  return type === 'any' || type === 'primitive';
+}
 
 function Scope(types) {
   this.types = Object.assign({}, types, rootTypes);
@@ -101,7 +119,7 @@ Scope.prototype.inferType = function(node) {
 
     switch(node.type) {
     case 'LogicalExpression':
-      node.inferredType = 'boolean';
+      this._inferLogicalExpression(node);
       break;
     case 'ExpressionStatement':
       node.inferredType = this.inferType(node.expression);
@@ -180,11 +198,25 @@ Scope.prototype.assertIndentifiersExist = function(node) {
   }
 };
 
+Scope.prototype._inferLogicalExpression = function(node) {
+  var left = this.inferType(node.left),
+    right = this.inferType(node.right);
+
+  if (left !== 'boolean') {
+    throw new nodeError(node, `Left operand of ${node.operator} must be boolean.`);
+  }
+
+  if (right !== 'boolean') {
+    throw new nodeError(node, `Right operand of ${node.operator} must be boolean.`);
+  }
+
+  node.inferredType = 'boolean';
+}
+
 Scope.prototype._inferLiteral = function(node) {
 
   // one hiccup: is this a regular expression literal? esparse does not help with this
   // we need to check the raw value to find out
-
   if (/^\/.+\/[igm]?$/.test(node.raw)) {
 
     // regular expression. construct it.
@@ -196,12 +228,15 @@ Scope.prototype._inferLiteral = function(node) {
     }
 
     node.inferredType = 'RegExp';
+    return;
 
-  } else if (node.value === undefined) {
-    throw nodeError(node, 'undefined is not valid in rules');
-  } else {
-    node.inferredType = typeof node.value;
   }
+
+  if (node.value === undefined) {
+    throw nodeError(node, 'undefined is not valid in rules');
+  }
+
+  node.inferredType = typeof node.value;
 
 };
 
@@ -210,6 +245,7 @@ Scope.prototype._inferUnaryExpression = function(node) {
   if (!unaryOperatorTypes[node.operator]) {
     throw nodeError(node, 'Unknown operator "' + node.operator + '"');
   }
+
   node.inferredType = unaryOperatorTypes[node.operator];
 };
 
@@ -221,41 +257,53 @@ Scope.prototype._inferBinaryExpression = function(node) {
 
   if (node.operator === '+') {
 
-    if (left === 'string' && right === 'string') {
+    const validTypes = new Set(['any', 'primitive', 'string', 'number']);
+
+    if (!validTypes.has(left)) {
+      throw new nodeError(node, 'Invalid + expression: left operand is not a number or string')
+    }
+
+    if (!validTypes.has(right)) {
+      throw new nodeError(node, 'Invalid + expression: left operand is not a number or string')
+    }
+
+    if (left === 'number' && right === 'number') {
+      node.inferredType = 'number';
+    } else if (left === 'string' || right === 'string') {
       node.inferredType = 'string';
-    } else if (left === 'number' && right === 'number') {
-      node.inferredType = 'number';
-    } else if (node.left.type === 'CallExpression') {
-      node.inferredType = right;
-    } else if (node.right.type === 'CallExpression') {
-      node.inferredType = left;
-    } else if (left || right) {
-      node.inferredType = left || right;
-    } 
-
-  } else if (binaryArithmeticOperatorTypes[node.operator]) {
-
-    if ((left && left === 'number') && (right && right === 'number')) {
-      node.inferredType = left;
-    } else if (node.left.type === 'CallExpression' || node.right.type === 'CallExpression') {
-      node.inferredType = 'number';
     } else {
-      throw nodeError(node, 'Both sides of arithmetic ' + node.operator +
-        ' must have type number or be CallExpression, but got ' + left + ' and ' + right);
+      node.inferredType = 'primitive';
     }
 
-  } else if (binaryComparisonOperatorTypes[node.operator]) {
+    return;
 
-    if (left && right && (left !== right)) {
-      throw nodeError(node, 'Both sides of boolean ' + node.operator +
-        ' must have the same type, but got ' + left + ' and ' + right);
-    } else {
-      node.inferredType = 'boolean';
-    }
-
-  } else {
-    throw nodeError(node, 'Unknown operator "' + node.operator + '"');
   }
+
+  if (binaryArithmeticOperatorTypes[node.operator]) {
+
+    const validTypes = new Set(['any', 'primitive', 'number']);
+
+    if (!validTypes.has(left)) {
+      throw new nodeError(node, `Invalid ${node.operator} expression: left operand is not a number.`);
+    }
+
+    if (!validTypes.has(right)) {
+      throw new nodeError(node, `Invalid ${node.operator} expression: right operand is not a number.`);
+    }
+
+    node.inferredType = 'number';
+    return;
+
+  }
+
+  if (binaryComparisonOperatorTypes[node.operator]) {
+
+    node.inferredType = 'boolean';
+    return;
+
+  }
+
+  throw nodeError(node, 'Unknown operator "' + node.operator + '"');
 
 };
 
@@ -278,36 +326,46 @@ Scope.prototype._inferCallExpression = function(node) {
 
   var functionSignature = this.inferType(node.callee);
 
-  if (typeof functionSignature === 'object') {
+  if (fuzzyType(functionSignature)) {
+    functionSignature = this._inferMemberExpressionAsStringMethod(node.callee);
+  }
 
-    node.inferredType = functionSignature.returnType;
-    node.callee.inferredType = 'Function';
+  if (typeof functionSignature !== 'object') {
+    throw nodeError(node, 'Type error: Function call on target that is not a function.');
+  }
 
-    // check the type and arity of the arguments
+  node.inferredType = functionSignature.returnType;
+  node.callee.inferredType = 'Function';
 
-    if (Array.isArray(functionSignature.args)) {
+  // check the type and arity of the arguments
 
-      if (node.arguments.length !== functionSignature.args.length) {
-        throw nodeError(node, 'method expects ' + functionSignature.args.length +
-          ' arguments, but got ' + node.arguments.length + ' instead');
-      }
+  if (typeof functionSignature.args === 'function') {
+    functionSignature.args(this, node);
+    return;
+  }
 
-      node.arguments.forEach(function(arg, i) {
+  if (!Array.isArray(functionSignature.args)) {
+    return;
+  }
 
-        if (this.inferType(arg) && arg.inferredType !== functionSignature.args[i]) {
-          throw nodeError(arg, 'method expects argument ' + (i+1) + ' to be a ' +
-            functionSignature.args[i] + ', but got ' + arg.inferredType);
-        }
+  if (node.arguments.length !== functionSignature.args.length) {
+    throw nodeError(node, 'method expects ' + functionSignature.args.length +
+      ' arguments, but got ' + node.arguments.length + ' instead');
+  }
 
-      }, this);
+  node.arguments.forEach(function(arg, i) {
+    var argType = this.inferType(arg);
 
-    } else if (typeof functionSignature.args === 'function') {
-      functionSignature.args(this, node);
+    if (fuzzyType(argType)) {
+      return;
     }
 
-  } else if (functionSignature !== undefined) {
-    throw nodeError(node, 'result of expression is not a function or method');
-  }
+    if (argType !== functionSignature.args[i]) {
+      throw nodeError(arg, 'method expects argument ' + (i+1) + ' to be a ' +
+        functionSignature.args[i] + ', but got ' + arg.inferredType);
+    }
+
+  }, this);
 
 };
 
@@ -315,19 +373,34 @@ Scope.prototype._inferMemberExpression = function(node) {
 
   var objectType = this.inferType(node.object);
 
-  if (properties[objectType] && properties[objectType][node.property.name]) {
-    node.inferredType = properties[objectType][node.property.name];
-  } else if (objectType === 'object' || !objectType) {
-
-    // so it's a (sub)property of auth. it could be a string, check those members
-    if (properties.string[node.property.name]) {
-      node.inferredType = properties.string[node.property.name];
-    }
-
-  } else if (objectType) {
-    throw nodeError(node, objectType + ' has no member "' + node.property.name + '"');
+  if (isPrimitiveType(objectType) && !properties.string[node.property.name]) {
+    throw new nodeError(node, `No such method/property '${node.property.name}'`)
   }
 
+  if (!properties[objectType]) {
+    node.inferredType = 'any';
+    return;
+  }
+
+  node.inferredType = properties[objectType][node.property.name];
+
+  if (!node.inferredType) {
+    throw new nodeError(node, `Could not find property "${node.property.name}" of "${objectType}"`);
+  }
+};
+
+Scope.prototype._inferMemberExpressionAsStringMethod = function(node) {
+
+  var inferredType = properties.string[node.property.name];
+
+  if (!inferredType || typeof inferredType !== 'object') {
+    node.inferredType = 'any';
+  } else {
+    node.inferredType = inferredType;
+    node.object.inferredType = 'string';
+  }
+
+  return node.inferredType;
 };
 
 Scope.prototype._inferConditionalExpression = function(node) {
@@ -337,8 +410,12 @@ Scope.prototype._inferConditionalExpression = function(node) {
 
   if (consequent === alternate) {
     node.inferredType = consequent;
+    return;
   }
 
+  const isPromitive = isPrimitiveType(consequent) && isPrimitiveType(alternate);
+
+  node.inferredType = isPromitive ? 'primitive' : 'any';
 };
 
 module.exports = Scope;

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -40,10 +40,11 @@ var invalidRules = [
   'root.child($here).exists() ? auth.foo.contains("bar", "baz") : false', // nested argument error
   '$somewhere === "over the rainbow"', // $somewhere is undefined
   'skies === "blue"', // skies is undefined
-  '"the dreams that you dare to dream" === true', // binary expression needs same type on both sides
   'root.hasChildren("foo", "bar")', // hasChildren takes an array
   'root.hasChildren(["foo", 7])', // hasChildren only takes strings
-  'root.child("str").val().matches("/foo/")' // matches only takes a regular expression literal
+  'root.child("str").val().matches("/foo/")', // matches only takes a regular expression literal
+  'auth.foo.notFound() == false', // auth properties can only be an object or a primitives
+  'root.val().notFound == false' // val only returns primitives.
 ];
 
 var ruleEvaluationTests = [{


### PR DESCRIPTION
Rule parsing changes:

- Logical expressions need to have boolean type values on both sides.

    ```js
    auth.foo && data.exists() // invalid
    auth.foo == true && data.exists() // valid
    ```

- Few type related error when a type cannot be inferred (logical expressions are the only ones strictly needing an inferred boolean type).
- Comparator expressions do not need to have matching type on both sides.

Parsing the rules should only throw if a rule cannot be published. Anything else should be caught during test run time.

Fix #62 