### PR TITLE
non-existent properties are treated as null

### DIFF
--- a/lib/parser/rule.js
+++ b/lib/parser/rule.js
@@ -194,44 +194,37 @@ RuleEvaluator.prototype._evalConditionalExpression = function(node) {
 RuleEvaluator.prototype._evalMemberExpression = function(node) {
 
   var object = this.evaluate(node.object),
-    property = object[node.property.name];
+    property = object && object[node.property.name],
+    isPatched = typeof object === 'string' && stringMethods[node.property.name];
 
-  if (typeof object === 'string' && stringMethods[node.property.name]) {
-
-    // swizzle in the string methods, if object is a string
-    return function() {
-      var args = Array.prototype.slice.call(arguments, 0);
-      return stringMethods[node.property.name].apply(null, [object].concat(args));
-    };
-
-  } else if (typeof property === 'function') {
-
-    return function() {
-      return property.apply(object, arguments);
-    };
-
-  } else if (property !== undefined) {
-    return property;
-  } else {
-    throw nodeError(node, object + ' has no property "' + node.property.name + '"');
+  if (isPatched) {
+    property = stringMethods[node.property.name];
   }
+
+  if (property === undefined) {
+    return null;
+  }
+
+  if (typeof property !== 'function') {
+    return property;
+  }
+
+  return isPatched ? property.bind(null, object) : property.bind(object);
 
 };
 
 RuleEvaluator.prototype._evalCallExpression = function(node) {
 
-  // get the arguments first
   var methodArguments = node.arguments.map(function(argument) {
-    return this.evaluate(argument);
-  }, this);
+      return this.evaluate(argument);
+    }, this),
+    method = this.evaluate(node.callee);
 
-  var method = this.evaluate(node.callee);
-  if (typeof method === 'function') {
-    return method.apply(null, methodArguments);
-  } else {
+  if (typeof method !== 'function') {
     throw nodeError(node, method + ' is not a function or method');
   }
 
+  return method.apply(null, methodArguments);
 };
 
 RuleEvaluator.prototype._evalArrayExpression = function(node) {

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -200,6 +200,13 @@ describe('Ruleset', function() {
       expect(result.allowed).to.be.false;
     });
 
+    it('should treat nonexistent properties of "auth" as null', function(){
+      var root = new RuleDataSnapshot(RuleDataSnapshot.convert({'a': 1})),
+          rules = new Ruleset({rules: {'.write': 'auth.x === null'}}),
+          result = rules.tryWrite('/a', root, 2, {});
+      expect(result.allowed).to.be.true;
+    });
+
   });
 
   describe('#get', function() {


### PR DESCRIPTION
It includes deep properties: “auth.foo.bar”.

fix #60 