### PR TITLE
Fix rule evaluation error handling (2)

### DIFF
--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -324,8 +324,6 @@ Ruleset.prototype.tryPatch = function(path, root, newData, auth, skipWrite, skip
 
 Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrite, skipValidate, skipOnNoValue) {
 
-  result.allowed = true;
-
   // walk down the rules hierarchy -- to get the .write and .validate rules along here
   (function traverse(pathParts, remainingPath, rules, wildchildren) {
 
@@ -358,7 +356,6 @@ Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrit
         }
 
       } catch(e) {
-        result.allowed = false;
         result.writePermitted = false;
         result.info += e.message + '\n';
       }
@@ -387,7 +384,6 @@ Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrit
         }
 
       } catch(e) {
-        result.allowed = false;
         result.validated = false;
         result.info += e.message + '\n';
       }
@@ -430,7 +426,7 @@ Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrit
 
   })([], pathSplitter(path), this._rules, {});
 
-  result.allowed = result.allowed && result.writePermitted && result.validated;
+  result.allowed = result.writePermitted && result.validated;
 
   if (!result.writePermitted) {
     result.info += 'No .write rule allowed the operation.\n';
@@ -440,8 +436,6 @@ Ruleset.prototype._tryWrite = function(path, root, newDataRoot, result, skipWrit
     result.info += 'Write was denied.';
   } else if (!result.allowed) {
     result.info += 'Write was denied.';
-  } else {
-    result.info += 'Write was allowed.';
   }
 
   return result;


### PR DESCRIPTION
Correction to PR #66. Related #61.

An evaluation error, only the test of that rule, not the entire operation. If the write rule below allow the operation, the operation is valid.