### PR TITLE
Include patch operations documentations

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -98,6 +98,18 @@ describe('A set of rules and data', function() {
     expect({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d' })
     .can.write(true).to.path('users/password:3403291b-fdc9-4995-9a54-9656241c835d/on-fire');
 
+    expect(targaryen.users.password)
+    .cannot.patch({
+      'users/password:3403291b-fdc9-4995-9a54-9656241c835d/on-fire': null,
+      'users/password:3403291b-fdc9-4995-9a54-9656241c835d/innocent': true
+    });
+
+    expect({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d' })
+    .can.patch({
+      'users/password:3403291b-fdc9-4995-9a54-9656241c835d/on-fire': true,
+      'users/password:3403291b-fdc9-4995-9a54-9656241c835d/innocent': null
+    });
+
   });
 
 });
@@ -136,6 +148,18 @@ describe('A set of rules and data', function() {
 
     expect({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d'})
     .canWrite('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/onFire', true);
+
+    expect({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d'})
+    .canPatch({
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/onFire': true,
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/innocent': null
+    });
+
+    expect({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d'})
+    .cannotPatch({
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/onFire': null,
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/innocent': true
+    });
 
   });
 

--- a/docs/chai/README.md
+++ b/docs/chai/README.md
@@ -64,5 +64,6 @@ mocha examples/<name of example>.js
 - `chai.Assertion.cannot`: asserts that this is a negative test, i.e., the specified operation ought to fail.
 - `chai.Assertion.read`: asserts that this test is for a read operation.
 - `chai.Assertion.write(data)`: asserts that this test is for a write operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
+- `chai.Assertion.patch(data)`: asserts that this test is for a patch (or multi-location update) operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
 - `chai.Assertion.path(firebasePath)`: asserts the path against which the operation should be conducted. This method actually tries the damn operation.
 

--- a/docs/jasmine/README.md
+++ b/docs/jasmine/README.md
@@ -61,6 +61,8 @@ jasmine spec/security/<name of example>.js
   - `github`: a user authenticated by their Github account.
 - `expect(auth).canRead(path)`: asserts that the given path is readable by a user with the given authentication data.
 - `expect(auth).cannotRead(path)`: asserts that the given path is not readable by a user with the given authentication data.
- - `expect(auth).canWrite(path, data)`: asserts that the given path is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).canWrite(path, data)`: asserts that the given path is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
 - `expect(auth).cannotWrite(path, data)`: asserts that the given path is not writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).canPatch(patch, data)`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).cannotPatch(patch, data)`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
 


### PR DESCRIPTION
My team spent some time trying to test multi-location operations using the `write` operator.
This should prevent the headache for everyone else.