### PR TITLE
Fix helpers

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,27 +4,41 @@ exports.trimLeft = function(path) {
   path = path || '';
 
   return path.replace(/^\/+/, '');
-}
+};
 
 exports.trimRight = function(path) {
   path = path || '';
 
   return path.replace(/\/+$/, '');
-}
+};
 
 exports.trim = function(path) {
   return exports.trimLeft(exports.trimRight(path));
-}
+};
 
 exports.pathMerger = function(root, path) {
   root = exports.trim(root);
   path = exports.trimLeft(path);
 
+  if (!root) {
+    return path;
+  }
+
+  if (!path) {
+    return root;
+  }
+
   return root + '/' + path;
-}
+};
 
 exports.pathSplitter = function(path) {
-  return exports.trimLeft(path).split('/');
+  path = exports.trimLeft(path);
+
+  if (!path) {
+    return [];
+  }
+
+  return path.split('/');
 };
 
 exports.makeNewDataSnap = function() {

--- a/test/spec/lib/helpers.js
+++ b/test/spec/lib/helpers.js
@@ -9,6 +9,8 @@ describe('helpers', function() {
 
     it('should merge path', function() {
       expect(helpers.pathMerger('foo', 'bar/baz')).to.equal('foo/bar/baz');
+      expect(helpers.pathMerger('foo', '')).to.equal('foo');
+      expect(helpers.pathMerger('', 'bar/baz')).to.equal('bar/baz');
     });
 
     it('should trim root path', function() {
@@ -26,6 +28,11 @@ describe('helpers', function() {
     it('should split the path', function() {
       expect(helpers.pathSplitter('foo/bar/baz')).to.eql(['foo', 'bar', 'baz']);
     });
+
+    it('should no split empty path', function() {
+      expect(helpers.pathSplitter('')).to.eql([]);
+    });
+
 
     it('should trim the beginning of the path', function() {
       expect(helpers.pathSplitter('/foo/bar/baz')).to.eql(['foo', 'bar', 'baz']);


### PR DESCRIPTION
Path splitter and joiner can now handle empty paths.