### PR TITLE
Evaluate CallExpression within MemberExpression

### DIFF
--- a/lib/parser/rule.js
+++ b/lib/parser/rule.js
@@ -194,9 +194,10 @@ RuleEvaluator.prototype._evalConditionalExpression = function(node) {
 RuleEvaluator.prototype._evalMemberExpression = function(node) {
 
   var object = this.evaluate(node.object),
-    key = node.computed ? this.evaluate(node.property) : node.property.name,
-    property = object && object[key],
-    isPatched = typeof object === 'string' && stringMethods[key];
+    propIsCall = node.property.type === 'CallExpression',
+    prop = propIsCall ? this.evaluate(node.property) : node.property.name,
+    property = object && object[prop],
+    isPatched = typeof object === 'string' && stringMethods[node.property.name];
 
   if (isPatched) {
     property = stringMethods[key];

--- a/test/integration/rules.json
+++ b/test/integration/rules.json
@@ -18,6 +18,11 @@
           ".validate": "$from !== $to"
         }
       }
+    },
+    "chats": {
+      "$chatID": {
+        ".read": "root.child('chats').child($chatID).child('orgID').val() != null && auth.orgs != null && auth.orgs[root.child('chats').child($chatID).child('orgID').val()] == true"
+      }
     }
   }
 }

--- a/test/integration/tests.json
+++ b/test/integration/tests.json
@@ -25,13 +25,27 @@
         "clearance-level": 8,
         "ticketagent": true
       }
+    },
+    "chats": {
+      "chat-01": {
+        "orgID": "org-01"
+      }
     }
   },
   "users": {
     "an author": { "uid": "password:ad7ebe2e-f547-4110-bda8-678af95b7efd" },
-    "John Smith": { "uid": "password:bb9c1467-8ad3-4b33-8913-f2b491cdbb86" }
+    "John Smith": { "uid": "password:bb9c1467-8ad3-4b33-8913-f2b491cdbb86" },
+    "org user": {
+      "uid": "password:53b20901-4c02-4ad9-95f6-5c2622ff09b1",
+      "orgs": {
+        "org-01": true
+      }
+    }
   },
   "tests": {
+    "chats/chat-01": {
+      "canRead": [ "org user" ]
+    },
     "posts/existing-post": {
       "canRead": [ "John Smith" ]
     },


### PR DESCRIPTION
Fixes #75 

Let me know if you'd like me to write tests other than integration. I tried the Jasmine tests first, but they didn't appear to run.

Essentially, `CallExpression`s that were inside of a `MemberExpression` (ie: `object[foobar()]`) were not being evaluated.

This PR fixes that.

Please let me know if I've implemented this in a sub-optimal way. I'm more than happy to make changes.