### PR TITLE
Format source based on eslint xo shared configuration

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,29 @@ env:
   commonjs: true
   es6: true
 rules:
+  strict:
+    - error
+    - safe
+  no-extend-native:
+    - error
+  no-bitwise:
+    - error
+  eqeqeq:
+    - error
+    - smart
+  no-use-before-define:
+    - error
+    - functions: false
+      classes: false
+  node/no-unsupported-features:
+    - error
+    - version: 4
+  no-caller:
+    - error
+  no-invalid-regexp:
+    - error
+
+  # styling
   indent:
     - error
     - 2
@@ -18,12 +41,6 @@ rules:
   semi:
     - error
     - always
-  strict:
-    - error
-    - safe
-  node/no-unsupported-features:
-    - error
-    - version: 4
   space-in-parens:
     - error
     - never
@@ -31,5 +48,19 @@ rules:
     - error
     - never
   array-bracket-spacing: 
+    - error
+    - never
+  camelcase:
+    - error
+  curly:
+    - error
+  wrap-iife:
+    - error
+    - inside
+  new-cap:
+    - error
+  no-trailing-spaces:
+    - error
+  comma-dangle:
     - error
     - never

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,21 +1,26 @@
 plugins:
   - node
-extends: 'eslint:recommended'
+extends: xo
 env:
   node: true
   commonjs: true
   es6: true
+parserOptions: 
+  ecmaFeatures: 
+    jsx: false
+    experimentalObjectRestSpread: false
+  ecmaVersion: 2016
+  sourceType: script
 rules:
-  strict:
-    - error
-    - safe
-  no-extend-native:
-    - error
-  no-bitwise:
-    - error
+  
+  # possible errors
   eqeqeq:
     - error
     - smart
+  no-confusing-arrow:
+    - error
+  no-eq-null:
+    - "off"
   no-use-before-define:
     - error
     - functions: false
@@ -23,44 +28,42 @@ rules:
   node/no-unsupported-features:
     - error
     - version: 4
-  no-caller:
+  no-var:
     - error
-  no-invalid-regexp:
+  strict:
     - error
+    - safe
 
   # styling
+  arrow-body-style:
+    - error
+    - as-needed
+  brace-style:
+    - error
+    - 1tbs
+    - allowSingleLine: true
   indent:
     - error
     - 2
-  linebreak-style:
-    - error
-    - unix
-  quotes:
-    - error
-    - single
-  semi:
+  lines-around-directive:
     - error
     - always
-  space-in-parens:
+  newline-after-var:
     - error
-    - never
-  computed-property-spacing: 
+    - always
+  object-shorthand:
     - error
-    - never
-  array-bracket-spacing: 
+  one-var:
     - error
-    - never
-  camelcase:
+    - initialized: never
+      uninitialized: always
+  padded-blocks:
+    - "off"
+  prefer-arrow-callback:
     - error
-  curly:
+    - allowNamedFunctions: true
+  prefer-const:
     - error
-  wrap-iife:
-    - error
-    - inside
-  new-cap:
-    - error
-  no-trailing-spaces:
-    - error
-  comma-dangle:
+  space-before-function-paren:
     - error
     - never

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+lint.html
 
 # Runtime data
 pids

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,12 @@
 {
+  "esversion": 6,
   "freeze": true,
   "node": true,
   "bitwise": true,
   "camelcase": true,
   "curly": true,
   "eqeqeq": true,
+  "eqnull": true,
   "immed": true,
   "indent": 2,
   "latedef": "nofunc",
@@ -19,12 +21,16 @@
   "trailing": true,
   "smarttabs": true,
   "globals": {
-    "expect"     : false,
-    "describe"   : false,
-    "it"         : false,
-    "before"     : false,
-    "beforeEach" : false,
-    "after"      : false,
-    "afterEach"  : false
+    "after"       : false,
+    "afterEach"   : false,
+    "before"      : false,
+    "beforeEach"  : false,
+    "describe"    : false,
+    "expect"      : false,
+    "it"          : false,
+    "jasmine"     : false,
+    "pending"     : false,
+    "sinon"       : false,
+    "xdescribe"   : false
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "4"
   - "6"
+script:
+  - npm run test
+  - npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+Pull Requests (PR) are welcomes.
+
+
+## Installing
+
+Fork [Targaryen], then:
+
+```bash
+git clone git@github.com:your-user-id/targaryen.git
+cd targaryen
+git remote add upstream https://github.com/goldibex/targaryen.git
+npm install
+```
+
+
+## Feature branch
+
+Avoid working fixes and new features in your master branch. It will prevent you
+from submitting focused pull request or from working on more than one
+fix/feature at a time.
+
+Instead, create a branch for each fix or feature:
+```bash
+git checkout master
+git pull upstream master
+git checkout -b <branch-name>
+```
+
+Work and commit the fixes/features, and then push your branch:
+```bash
+git push origin <branch-name>
+```
+
+Visit your fork and send a PR from that branch; the PR form URL will have this
+form:
+
+    https://github.com/goldibex/targaryen/compare/master...<your-github-username>:<branch-name>
+
+Once your PR is accepted:
+```bash
+git checkout master
+git push origin --delete <branch-name>
+git branch -D <branch-name>
+git pull upstream master
+```
+
+
+## Running tests
+
+```bash
+npm install
+npm test
+```
+
+Or for coverage info:
+```
+npm run coverage
+```
+
+
+## Linting and formatting
+
+Try to follow the style of the scripts you are editing.
+
+Before submitting a PR, run [eslint], format styling inconsistencies and fix
+insecure idioms:
+
+```bash
+npm install
+
+# report errors
+npm run lint
+
+# try to fix automatically styling errors
+npm run format
+
+# report error in html (in lint.html)
+npm run lint:html
+```
+
+
+[Targaryen]: https://github.com/goldibex/targaryen
+[eslint]: http://eslint.org/

--- a/bin/.eslintrc.yml
+++ b/bin/.eslintrc.yml
@@ -1,3 +1,4 @@
 extends: '../.eslintrc.yml'
 rules:
   no-console: "off"
+  no-restricted-modules: "off"

--- a/bin/targaryen
+++ b/bin/targaryen
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 
 'use strict';
-var fs = require('fs');
-var stripJsonComments = require('strip-json-comments');
 
-var path = require('path'),
-  Table = require('cli-table'),
-  colors = require('colors'),
-  helpers = require('../lib/util'),
-  TestJig = require('../lib/test-cmd'),
-  argv = require('minimist')(process.argv.slice(2), { boolean: true });
+const fs = require('fs');
+const stripJsonComments = require('strip-json-comments');
+
+const path = require('path');
+const Table = require('cli-table');
+const colors = require('colors');
+const helpers = require('../lib/util');
+const TestJig = require('../lib/test-cmd');
+const argv = require('minimist')(process.argv.slice(2), {boolean: true});
 
 if (argv._.length < 2) {
 
@@ -18,32 +19,31 @@ if (argv._.length < 2) {
 
 }
 
+const rulesJSONPath = path.resolve(argv._[0]);
+const testJSONPath = path.resolve(argv._[1]);
+const rulesJSONFile = fs.readFileSync(rulesJSONPath);
+const rules = JSON.parse(stripJsonComments(rulesJSONFile.toString()));
+const tests = require(testJSONPath);
 
-var rulesJSONPath = path.resolve(argv._[0]),
-  testJSONPath = path.resolve(argv._[1]),
-  rulesJSONFile = fs.readFileSync(rulesJSONPath),
-  rules = JSON.parse(stripJsonComments(rulesJSONFile.toString())),
-  tests = require(testJSONPath);
+const jig = new TestJig(rules, tests);
+const results = jig.run();
+const totalCount = results.length;
+const table = new Table({
+  head: ['Path', 'Type', 'Auth', 'Expect', 'Got']
+});
+let failCount = 0;
 
-var jig = new TestJig(rules, tests),
-  results = jig.run(),
-  totalCount = results.length,
-  failCount = 0,
-  table = new Table({
-    head: ['Path', 'Type', 'Auth', 'Expect', 'Got']
-  });
-
-results.forEach(function(result) {
+results.forEach(result => {
 
   if (argv.debug) {
     console.log(result.info);
     console.log();
   }
 
-  var expected = result.expected ? '✓'.green : '✖'.red,
-    actual = result.allowed ? '✓'.green : '✖'.red;
+  const expected = result.expected ? '✓'.green : '✖'.red;
+  const actual = result.allowed ? '✓'.green : '✖'.red;
+  let authStr;
 
-  var authStr;
   if (result.auth && result.auth.$description) {
     authStr = result.auth.$description;
   } else if (typeof result.auth === 'string') {

--- a/bin/targaryen
+++ b/bin/targaryen
@@ -53,7 +53,7 @@ results.forEach(function(result) {
   }
 
   if (expected === actual) {
-    table.push([ result.path, result.type, authStr, expected, actual ]);
+    table.push([result.path, result.type, authStr, expected, actual]);
   } else {
     table.push([
       colors.bgRed(result.path),

--- a/lib/database.js
+++ b/lib/database.js
@@ -3,6 +3,7 @@
  * tree and the current user state.
  *
  */
+
 'use strict';
 
 const paths = require('./paths');
@@ -140,8 +141,8 @@ class Database {
 
     let newRoot = this.root;
 
-    const pathsToTest = Object.keys(patch).map(function(endPath){
-      var pathToNode = paths.join(path, endPath);
+    const pathsToTest = Object.keys(patch).map(endPath => {
+      const pathToNode = paths.join(path, endPath);
 
       newRoot = newRoot.$set(pathToNode, patch[endPath], undefined, now);
 
@@ -149,11 +150,11 @@ class Database {
     });
 
     const newData = this.with({data: newRoot, now});
-    const writeResults =  pathsToTest.map(
+    const writeResults = pathsToTest.map(
       p => this.rules.tryWrite(p, this, newData, patch, now)
     );
 
-    return results.update(path, this, newData, patch, writeResults);
+    return results.update(path, this, patch, writeResults);
   }
 
 }

--- a/lib/parser/node-error.js
+++ b/lib/parser/node-error.js
@@ -3,7 +3,8 @@
 
 function nodeError(node, msg) {
 
-  var err = new Error(node.original + ': ' + msg);
+  const err = new Error(node.original + ': ' + msg);
+
   err.name = 'ParseError';
   err.start = node.range[0];
   err.end = node.range[1];

--- a/lib/parser/rule.js
+++ b/lib/parser/rule.js
@@ -1,18 +1,21 @@
 
 'use strict';
 
-var esprima = require('esprima'),
-  Scope = require('./scope'),
-  nodeError = require('./node-error'),
-  stringMethods = require('./string-methods');
+const esprima = require('esprima');
+const Scope = require('./scope');
+const nodeError = require('./node-error');
+const stringMethods = require('./string-methods');
 
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}
 
 function Rule(ruleStr, wildchildren, isWrite) {
 
   this._str = ruleStr;
   this.wildchildren = wildchildren;
 
-  var localTypes = wildchildren.reduce(function(otherTypes, wildchild) {
+  const localTypes = wildchildren.reduce((otherTypes, wildchild) => {
     otherTypes[wildchild] = 'string';
     return otherTypes;
   }, {});
@@ -21,8 +24,8 @@ function Rule(ruleStr, wildchildren, isWrite) {
     localTypes.newData = 'RuleDataSnapshot';
   }
 
-  var scope = new Scope(localTypes);
-  var ast = esprima.parse(ruleStr, { range: true });
+  const scope = new Scope(localTypes);
+  const ast = esprima.parse(ruleStr, {range: true});
 
   if (ast.body.length !== 1 || ast.body[0].type !== 'ExpressionStatement') {
     throw new Error('Rule is not a single expression');
@@ -36,9 +39,9 @@ function Rule(ruleStr, wildchildren, isWrite) {
     // slice the chunk of text from the rule expression associated with this node
     node.original = ruleStr.slice(node.range[0], node.range[1]);
 
-    Object.keys(node).forEach(function(propertyName) {
+    Object.keys(node).forEach(propertyName => {
 
-      [].concat(node[propertyName]).forEach(function(property) {
+      [].concat(node[propertyName]).forEach(property => {
 
         if (typeof property === 'object' && property !== null && property.range) {
           markOriginal(property);
@@ -67,7 +70,6 @@ Rule.prototype.toString = function() {
   return this._str;
 };
 
-
 function RuleEvaluator(state) {
   this.state = state;
 }
@@ -77,7 +79,7 @@ RuleEvaluator.prototype.evaluate = function(node, skipOnNoValue) {
     return true;
   }
 
-  switch(node.type) {
+  switch (node.type) {
   case 'ExpressionStatement':
     return this.evaluate(node.expression);
   case 'LogicalExpression':
@@ -105,13 +107,11 @@ RuleEvaluator.prototype.evaluate = function(node, skipOnNoValue) {
 };
 
 RuleEvaluator.prototype._evalIdentifier = function(node) {
-
-  if (this.state.hasOwnProperty(node.name)) {
-    return this.state[node.name];
-  } else {
+  if (!hasOwnProperty(this.state, node.name)) {
     throw nodeError(node, 'unknown variable ' + node.name);
   }
 
+  return this.state[node.name];
 };
 
 RuleEvaluator.prototype._evalLiteral = function(node) {
@@ -120,11 +120,12 @@ RuleEvaluator.prototype._evalLiteral = function(node) {
 
 RuleEvaluator.prototype._evalLogicalExpression = function(node) {
 
-  if (node.operator === '&&') {
+  switch (node.operator) {
+  case '&&':
     return this.evaluate(node.left) && this.evaluate(node.right);
-  } else if (node.operator === '||') {
+  case '||':
     return this.evaluate(node.left) || this.evaluate(node.right);
-  } else {
+  default:
     throw nodeError(node, 'unknown logical operator ' + node.operator);
   }
 
@@ -132,10 +133,10 @@ RuleEvaluator.prototype._evalLogicalExpression = function(node) {
 
 RuleEvaluator.prototype._evalBinaryExpression = function(node) {
 
-  var left = this.evaluate(node.left),
-    right = this.evaluate(node.right);
+  const left = this.evaluate(node.left);
+  const right = this.evaluate(node.right);
 
-  switch(node.operator) {
+  switch (node.operator) {
   case '+':
     return left + right;
   case '-':
@@ -180,27 +181,17 @@ RuleEvaluator.prototype._evalUnaryExpression = function(node) {
 };
 
 RuleEvaluator.prototype._evalConditionalExpression = function(node) {
+  const test = this.evaluate(node.test);
 
-  var test = this.evaluate(node.test);
-
-  if (test) {
-    return this.evaluate(node.consequent);
-  } else {
-    return this.evaluate(node.alternate);
-  }
-
+  return test ? this.evaluate(node.consequent) : this.evaluate(node.alternate);
 };
 
 RuleEvaluator.prototype._evalMemberExpression = function(node) {
 
-  var object = this.evaluate(node.object),
-    key = node.computed ? this.evaluate(node.property) : node.property.name,
-    property = object && object[key],
-    isPatched = typeof object === 'string' && stringMethods[key];
-
-  if (isPatched) {
-    property = stringMethods[key];
-  }
+  const object = this.evaluate(node.object);
+  const key = node.computed ? this.evaluate(node.property) : node.property.name;
+  const isPatched = typeof object === 'string' && stringMethods[key];
+  const property = isPatched ? stringMethods[key] : (object && object[key]);
 
   if (property === undefined) {
     return null;
@@ -216,10 +207,8 @@ RuleEvaluator.prototype._evalMemberExpression = function(node) {
 
 RuleEvaluator.prototype._evalCallExpression = function(node) {
 
-  var methodArguments = node.arguments.map(function(argument) {
-      return this.evaluate(argument);
-    }, this),
-    method = this.evaluate(node.callee);
+  const methodArguments = node.arguments.map(arg => this.evaluate(arg));
+  const method = this.evaluate(node.callee);
 
   if (typeof method !== 'function') {
     throw nodeError(node, method + ' is not a function or method');

--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -16,7 +16,7 @@ var binaryArithmeticOperatorTypes = {
   '-': true,
   '*': true,
   '/': true,
-  '%': true,
+  '%': true
 };
 
 var binaryComparisonOperatorTypes = {
@@ -203,15 +203,15 @@ Scope.prototype._inferLogicalExpression = function(node) {
     right = this.inferType(node.right);
 
   if (left !== 'boolean') {
-    throw new nodeError(node, `Left operand of ${node.operator} must be boolean.`);
+    throw nodeError(node, `Left operand of ${node.operator} must be boolean.`);
   }
 
   if (right !== 'boolean') {
-    throw new nodeError(node, `Right operand of ${node.operator} must be boolean.`);
+    throw nodeError(node, `Right operand of ${node.operator} must be boolean.`);
   }
 
   node.inferredType = 'boolean';
-}
+};
 
 Scope.prototype._inferLiteral = function(node) {
 
@@ -260,11 +260,11 @@ Scope.prototype._inferBinaryExpression = function(node) {
     const validTypes = new Set(['any', 'primitive', 'string', 'number']);
 
     if (!validTypes.has(left)) {
-      throw new nodeError(node, 'Invalid + expression: left operand is not a number or string')
+      throw nodeError(node, 'Invalid + expression: left operand is not a number or string');
     }
 
     if (!validTypes.has(right)) {
-      throw new nodeError(node, 'Invalid + expression: left operand is not a number or string')
+      throw nodeError(node, 'Invalid + expression: left operand is not a number or string');
     }
 
     if (left === 'number' && right === 'number') {
@@ -284,11 +284,11 @@ Scope.prototype._inferBinaryExpression = function(node) {
     const validTypes = new Set(['any', 'primitive', 'number']);
 
     if (!validTypes.has(left)) {
-      throw new nodeError(node, `Invalid ${node.operator} expression: left operand is not a number.`);
+      throw nodeError(node, `Invalid ${node.operator} expression: left operand is not a number.`);
     }
 
     if (!validTypes.has(right)) {
-      throw new nodeError(node, `Invalid ${node.operator} expression: right operand is not a number.`);
+      throw nodeError(node, `Invalid ${node.operator} expression: right operand is not a number.`);
     }
 
     node.inferredType = 'number';
@@ -374,7 +374,7 @@ Scope.prototype._inferMemberExpression = function(node) {
   var objectType = this.inferType(node.object);
 
   if (isPrimitiveType(objectType) && !properties.string[node.property.name]) {
-    throw new nodeError(node, `No such method/property '${node.property.name}'`)
+    throw nodeError(node, `No such method/property '${node.property.name}'`);
   }
 
   if (!properties[objectType]) {
@@ -385,7 +385,7 @@ Scope.prototype._inferMemberExpression = function(node) {
   node.inferredType = properties[objectType][node.property.name];
 
   if (!node.inferredType) {
-    throw new nodeError(node, `Could not find property "${node.property.name}" of "${objectType}"`);
+    throw nodeError(node, `Could not find property "${node.property.name}" of "${objectType}"`);
   }
 };
 

--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -1,9 +1,9 @@
 
 'use strict';
 
-var nodeError = require('./node-error');
+const nodeError = require('./node-error');
 
-var rootTypes = {
+const rootTypes = {
 
   auth: 'any',
   root: 'RuleDataSnapshot',
@@ -12,14 +12,14 @@ var rootTypes = {
 
 };
 
-var binaryArithmeticOperatorTypes = {
+const binaryArithmeticOperatorTypes = {
   '-': true,
   '*': true,
   '/': true,
   '%': true
 };
 
-var binaryComparisonOperatorTypes = {
+const binaryComparisonOperatorTypes = {
   '==': true,
   '!=': true,
   '===': true,
@@ -30,31 +30,31 @@ var binaryComparisonOperatorTypes = {
   '<=': true
 };
 
-var unaryOperatorTypes = {
+const unaryOperatorTypes = {
   '-': 'number',
   '!': 'boolean'
 };
 
-var properties = {
+const properties = {
 
   string: {
-    contains: { name: 'contains', args: ['string'], returnType: 'boolean' },
-    beginsWith: { name: 'beginsWith', args: ['string'], returnType: 'boolean' },
-    endsWith: { name: 'endsWith', args: ['string'], returnType: 'boolean' },
-    replace: { name: 'replace', args: ['string', 'string'], returnType: 'string' },
-    toLowerCase: { name: 'toLowerCase', args: [], returnType: 'string' },
-    toUpperCase: { name: 'toUpperCase', args: [], returnType: 'string' },
-    matches: { name: 'matches', args: ['RegExp'], returnType: 'boolean' },
+    contains: {name: 'contains', args: ['string'], returnType: 'boolean'},
+    beginsWith: {name: 'beginsWith', args: ['string'], returnType: 'boolean'},
+    endsWith: {name: 'endsWith', args: ['string'], returnType: 'boolean'},
+    replace: {name: 'replace', args: ['string', 'string'], returnType: 'string'},
+    toLowerCase: {name: 'toLowerCase', args: [], returnType: 'string'},
+    toUpperCase: {name: 'toUpperCase', args: [], returnType: 'string'},
+    matches: {name: 'matches', args: ['RegExp'], returnType: 'boolean'},
     length: 'number'
   },
   RuleDataSnapshot: {
-    val: { name: 'val', args: [], returnType: 'primitive'},
-    child: { name: 'child', args: ['string'], returnType: 'RuleDataSnapshot' },
-    parent: { name: 'parent', args: [], returnType: 'RuleDataSnapshot' },
-    hasChild: { name: 'hasChild', args: ['string'], returnType: 'boolean' },
+    val: {name: 'val', args: [], returnType: 'primitive'},
+    child: {name: 'child', args: ['string'], returnType: 'RuleDataSnapshot'},
+    parent: {name: 'parent', args: [], returnType: 'RuleDataSnapshot'},
+    hasChild: {name: 'hasChild', args: ['string'], returnType: 'boolean'},
     hasChildren: {
       name: 'hasChildren',
-      args: function(scope, node) {
+      args(scope, node) {
 
         if (node.arguments.length === 0) {
           return;
@@ -64,7 +64,7 @@ var properties = {
           throw nodeError(node, 'Too many arguments to hasChildren');
         }
 
-        var argument = node.arguments[0];
+        const argument = node.arguments[0];
 
         if (argument.type !== 'ArrayExpression') {
           throw nodeError(node, 'hasChildren takes 1 argument: an array of strings');
@@ -74,8 +74,8 @@ var properties = {
           throw nodeError(node, 'hasChildren got an empty array, expected some strings in there');
         }
 
-        for (var i = 0; i < argument.elements.length; i++) {
-          let argType = scope.inferType(argument.elements[i]);
+        for (let i = 0; i < argument.elements.length; i++) {
+          const argType = scope.inferType(argument.elements[i]);
 
           if (fuzzyType(argType)) {
             continue;
@@ -90,11 +90,11 @@ var properties = {
       },
       returnType: 'boolean'
     },
-    exists: { name: 'exists', args: [], returnType: 'boolean' },
-    getPriority: { name: 'getPriority', args: [], returnType: 'any'},
-    isNumber: { name: 'isNumber', args: [], returnType: 'boolean' },
-    isString: { name: 'isString', args: [], returnType: 'boolean' },
-    isBoolean: { name: 'isoolean', args: [], returnType: 'boolean' }
+    exists: {name: 'exists', args: [], returnType: 'boolean'},
+    getPriority: {name: 'getPriority', args: [], returnType: 'any'},
+    isNumber: {name: 'isNumber', args: [], returnType: 'boolean'},
+    isString: {name: 'isString', args: [], returnType: 'boolean'},
+    isBoolean: {name: 'isoolean', args: [], returnType: 'boolean'}
   }
 
 };
@@ -117,7 +117,7 @@ Scope.prototype.inferType = function(node) {
 
   if (!node.inferredType) {
 
-    switch(node.type) {
+    switch (node.type) {
     case 'LogicalExpression':
       this._inferLogicalExpression(node);
       break;
@@ -155,12 +155,12 @@ Scope.prototype.inferType = function(node) {
 };
 
 Scope.prototype.assertIndentifiersExist = function(node) {
-  var stack = [node];
+  const stack = [node];
 
   while (stack.length > 0) {
-    let currNode = stack.pop();
+    const currNode = stack.pop();
 
-    switch(currNode.type) {
+    switch (currNode.type) {
 
     case 'LogicalExpression':
     case 'BinaryExpression':
@@ -199,8 +199,8 @@ Scope.prototype.assertIndentifiersExist = function(node) {
 };
 
 Scope.prototype._inferLogicalExpression = function(node) {
-  var left = this.inferType(node.left),
-    right = this.inferType(node.right);
+  const left = this.inferType(node.left);
+  const right = this.inferType(node.right);
 
   if (left !== 'boolean') {
     throw nodeError(node, `Left operand of ${node.operator} must be boolean.`);
@@ -220,7 +220,7 @@ Scope.prototype._inferLiteral = function(node) {
   if (/^\/.+\/[igm]?$/.test(node.raw)) {
 
     // regular expression. construct it.
-    if ('igm'.indexOf(node.raw.slice(-1)) !== -1) {
+    if ('igm'.indexOf(node.raw.slice(-1)) > -1) {
       // we have a modifier letter
       node.value = new RegExp(node.raw.slice(1, -2), node.raw.slice(-1));
     } else {
@@ -249,11 +249,10 @@ Scope.prototype._inferUnaryExpression = function(node) {
   node.inferredType = unaryOperatorTypes[node.operator];
 };
 
-
 Scope.prototype._inferBinaryExpression = function(node) {
 
-  var left = this.inferType(node.left),
-    right = this.inferType(node.right);
+  const left = this.inferType(node.left);
+  const right = this.inferType(node.right);
 
   if (node.operator === '+') {
 
@@ -324,7 +323,7 @@ Scope.prototype._assertIdentifier = function(node) {
 
 Scope.prototype._inferCallExpression = function(node) {
 
-  var functionSignature = this.inferType(node.callee);
+  let functionSignature = this.inferType(node.callee);
 
   if (fuzzyType(functionSignature)) {
     functionSignature = this._inferMemberExpressionAsStringMethod(node.callee);
@@ -354,14 +353,14 @@ Scope.prototype._inferCallExpression = function(node) {
   }
 
   node.arguments.forEach(function(arg, i) {
-    var argType = this.inferType(arg);
+    const argType = this.inferType(arg);
 
     if (fuzzyType(argType)) {
       return;
     }
 
     if (argType !== functionSignature.args[i]) {
-      throw nodeError(arg, 'method expects argument ' + (i+1) + ' to be a ' +
+      throw nodeError(arg, 'method expects argument ' + (i + 1) + ' to be a ' +
         functionSignature.args[i] + ', but got ' + arg.inferredType);
     }
 
@@ -371,7 +370,7 @@ Scope.prototype._inferCallExpression = function(node) {
 
 Scope.prototype._inferMemberExpression = function(node) {
 
-  var objectType = this.inferType(node.object);
+  const objectType = this.inferType(node.object);
 
   if (isPrimitiveType(objectType) && !properties.string[node.property.name]) {
     throw nodeError(node, `No such method/property '${node.property.name}'`);
@@ -391,7 +390,7 @@ Scope.prototype._inferMemberExpression = function(node) {
 
 Scope.prototype._inferMemberExpressionAsStringMethod = function(node) {
 
-  var inferredType = properties.string[node.property.name];
+  const inferredType = properties.string[node.property.name];
 
   if (!inferredType || typeof inferredType !== 'object') {
     node.inferredType = 'any';
@@ -405,8 +404,8 @@ Scope.prototype._inferMemberExpressionAsStringMethod = function(node) {
 
 Scope.prototype._inferConditionalExpression = function(node) {
 
-  var consequent = this.inferType(node.consequent),
-    alternate = this.inferType(node.alternate);
+  const consequent = this.inferType(node.consequent);
+  const alternate = this.inferType(node.alternate);
 
   if (consequent === alternate) {
     node.inferredType = consequent;

--- a/lib/parser/string-methods.js
+++ b/lib/parser/string-methods.js
@@ -1,23 +1,23 @@
 
 'use strict';
 
-var replaceall = require('replaceall');
+const replaceall = require('replaceall');
 
 module.exports = {
 
-  contains: function(str, substr) {
+  contains(str, substr) {
     return str.indexOf(substr) !== -1;
   },
-  beginsWith: function(str, substr) {
+  beginsWith(str, substr) {
     return str.indexOf(substr) === 0;
   },
-  endsWith: function(str, substr) {
+  endsWith(str, substr) {
     return str.indexOf(substr) + substr.length === str.length;
   },
-  replace: function(str, substr, replacement) {
+  replace(str, substr, replacement) {
     return replaceall(substr, replacement, str);
   },
-  matches: function(str, regex) {
+  matches(str, regex) {
     return regex.test(str);
   }
 

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,6 +1,7 @@
 /**
  * Paths helpers functions to avoid multiple path separator issues.
  */
+
 'use strict';
 
 exports.trimLeft = function(path) {

--- a/lib/results.js
+++ b/lib/results.js
@@ -1,6 +1,7 @@
 /**
  * Helpers for each operation type.
  */
+
 'use strict';
 
 /**
@@ -8,19 +9,25 @@
  */
 class Result {
 
-  constructor(path, operationType, db, newDb, newValue) {
+  constructor(path, operationType, db, opts) {
     const isRead = operationType === 'read';
 
+    opts = opts || {};
+
+    if (!isRead && !opts.newDatabase) {
+      throw new Error('The resulting database should be provided.');
+    }
+
     this.path = path;
-    this.auth = isRead ? db.auth : newDb.auth;
+    this.auth = isRead ? db.auth : opts.newDatabase.auth;
     this.type = operationType;
     this.logs = [];
-    this.readPermitted = isRead ? false : true;
-    this.writePermitted = isRead ? true : false;
+    this.readPermitted = !isRead;
+    this.writePermitted = isRead;
     this.validated = true;
     this.database = db;
-    this.newDatabase = newDb;
-    this.newValue = newValue;
+    this.newDatabase = opts.newDatabase;
+    this.newValue = opts.newValue;
   }
 
   get allowed() {
@@ -112,20 +119,20 @@ class Result {
  * @return {Result}
  */
 exports.read = function(path, data) {
-  return new Result(path, 'read', data, undefined, undefined);
+  return new Result(path, 'read', data);
 };
 
 /**
  * Create the result for a write operation.
  *
- * @param  {string}      path     Path to node to write
- * @param  {Database}    data     Database to edit
- * @param  {Database}    newData  Resulting database
- * @param  {any}         newValue Value to edit with
+ * @param  {string}      path         Path to node to write
+ * @param  {Database}    data         Database to edit
+ * @param  {Database}    newDatabase  Resulting database
+ * @param  {any}         newValue     Value to edit with
  * @return {Result}
  */
-exports.write = function(path, data, newData, newValue) {
-  return new Result(path, 'write', data, newData, newValue);
+exports.write = function(path, data, newDatabase, newValue) {
+  return new Result(path, 'write', data, {newDatabase, newValue});
 };
 
 /**
@@ -134,17 +141,17 @@ exports.write = function(path, data, newData, newValue) {
  *
  * @param  {string}       path         Path to node to patch
  * @param  {Database}     data         Database to edit
- * @param  {Database}     newData      Resulting database
  * @param  {object}       patch        Values to edit with
  * @param  {array}        writeResults List of write eveluation result to merge.
  * @return {Result}
  */
-exports.update = function(path, data, newData, patch, writeResults) {
-  const result = new Result(path, 'patch', data, newData, patch);
+exports.update = function(path, data, patch, writeResults) {
+  const result = new Result(path, 'patch', data, {newDatabase: data, newValue: patch});
 
   result.writePermitted = true;
 
   writeResults.forEach(r => {
+    result.newDatabase = r.newDatabase;
     result.logs = result.logs.concat(r.logs);
     result.writePermitted = r.writePermitted && result.writePermitted;
     result.validated = r.validated && result.validated;

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -1,6 +1,7 @@
 /**
  * Create firebase rule set trees from firebase rules objects.
  */
+
 'use strict';
 
 const Rule = require('./parser/rule');
@@ -123,7 +124,7 @@ class Ruleset {
     let state = {
       root: data.snapshot('/'),
       auth: result.auth,
-      now: now
+      now
     };
 
     this.root.$traverse(path, (currentPath, rules, wildchildren) => {
@@ -231,7 +232,7 @@ class Ruleset {
       const allowed = rule.evaluate(state);
 
       result.add(path, kind, rule, allowed);
-    } catch(e) {
+    } catch (e) {
       result.add(path, kind, rule, e);
     }
   }
@@ -285,15 +286,18 @@ class RulesetNode {
     Object.defineProperties(this, {
       $name: {value: name},
       $isWildchild: {value: name && name.startsWith('$')},
-      $read: {value: rules['.read'] != null ? new Rule(rules['.read'].toString(), wildchildren, !isWrite) : null},
-      $write: {value: rules['.write'] != null ? new Rule(rules['.write'].toString(), wildchildren, isWrite) : null},
-      $validate: {value: rules['.validate'] != null ? new Rule(rules['.validate'].toString(), wildchildren, isWrite) : null}
+      $read: {value: rules['.read'] == null ? null : new Rule(rules['.read'].toString(), wildchildren, !isWrite)},
+      $write: {value: rules['.write'] == null ? null : new Rule(rules['.write'].toString(), wildchildren, isWrite)},
+      $validate: {value: rules['.validate'] == null ? null : new Rule(rules['.validate'].toString(), wildchildren, isWrite)}
     });
 
     // setup children rules
     const childrens = Object.keys(rules).filter(k => !k.startsWith('.') && !k.startsWith('$'));
 
-    childrens.forEach(k => (this[k] = new RulesetNode(stack.concat(k), rules[k])));
+    childrens.forEach(k => {
+      this[k] = new RulesetNode(stack.concat(k), rules[k]);
+    });
+
     this.$wildchild = wildchildName ? new RulesetNode(stack.concat(wildchildName), rules[wildchildName]) : null;
 
     Object.freeze(this);
@@ -313,7 +317,7 @@ class RulesetNode {
     let rules = this;
 
     for (let i = 0; i < parts.length; i++) {
-      let key = parts[i];
+      const key = parts[i];
 
       if (rules[key]) {
         rules = rules[key];

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,6 +1,7 @@
 /**
  * Create firebase data trees from various format.
  */
+
 'use strict';
 
 const paths = require('./paths');
@@ -275,7 +276,9 @@ class DataNode {
       const siblings = Object.keys(currSrc).filter(k => k !== key);
       const isLast = pathParts.length - i === 1;
 
-      siblings.forEach(k => (currDest[k] = currSrc[k]));
+      siblings.forEach(k => {
+        currDest[k] = currSrc[k];
+      });
 
       currSrc = currSrc[key] || {};
 
@@ -309,7 +312,7 @@ class DataNode {
     let currSrc = this;
     let dest = () => newRoot;
 
-    paths.split(path).every((key) => {
+    paths.split(path).every(key => {
       const siblings = Object.keys(currSrc).filter(k => k !== key);
 
       // If the path doesn't exist from this point,
@@ -322,12 +325,18 @@ class DataNode {
       // Or copy other items
       const currDest = dest();
 
-      siblings.forEach(k => (currDest[k] = currSrc[k]));
+      siblings.forEach(k => {
+        currDest[k] = currSrc[k];
+      });
 
       currSrc = currSrc[key];
 
       // We will only create the next level if there's anything to copy.
-      dest = () => (currDest[key] = {});
+      dest = () => {
+        currDest[key] = {};
+
+        return currDest[key];
+      };
 
       return true;
 

--- a/lib/test-cmd.js
+++ b/lib/test-cmd.js
@@ -4,11 +4,11 @@
  * Rule tests are define via a JSON object listing operations to simulate
  * against an initial data and authentication states.
  */
+
 'use strict';
 
 const database = require('./database');
 const paths = require('./paths');
-
 
 function TestJig(rules, testData, now) {
   now = now || Date.now();

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 /**
  * Common operations for test framework.
  */
+
 'use strict';
 
 const ruleset = require('./ruleset');
@@ -46,26 +47,30 @@ const users = exports.users = {
 
 };
 
-
 function getUserDescription(auth) {
 
-  if (auth === null || auth === undefined) {
+  if (auth == null) {
     return 'an unauthenticated user';
-  } else if (auth === users.facebook) {
-    return 'a user authenticated via Facebook';
-  } else if (auth === users.twitter) {
-    return 'a user authenticated via Twitter';
-  } else if (auth === users.anonymous) {
-    return 'a user authenticated anonymously';
-  } else if (auth === users.github) {
-    return 'a user authenticated via Github';
-  } else if (auth === users.google) {
-    return 'a user authenticated via Google';
-  } else if (auth === users.password) {
-    return 'a user authenticated via Password Login';
-  } else if (auth.$description) {
+  }
+
+  if (auth.$description) {
     return auth.$description;
-  } else {
+  }
+
+  switch (auth) {
+  case users.facebook:
+    return 'a user authenticated via Facebook';
+  case users.twitter:
+    return 'a user authenticated via Twitter';
+  case users.anonymous:
+    return 'a user authenticated anonymously';
+  case users.github:
+    return 'a user authenticated via Github';
+  case users.google:
+    return 'a user authenticated via Google';
+  case users.password:
+    return 'a user authenticated via Password Login';
+  default:
     return 'a user with credentials ' + JSON.stringify(auth);
   }
 
@@ -73,7 +78,7 @@ function getUserDescription(auth) {
 
 exports.readableError = function(result) {
 
-  var msg = 'Expected ' + getUserDescription(result.auth) +
+  let msg = 'Expected ' + getUserDescription(result.auth) +
     ' not to be able to read ' + result.path +
     ', but the rules allowed the read.';
 
@@ -87,7 +92,7 @@ exports.readableError = function(result) {
 
 exports.unreadableError = function(result) {
 
-  var msg = 'Expected ' + getUserDescription(result.auth) +
+  let msg = 'Expected ' + getUserDescription(result.auth) +
     ' to be able to read ' + result.path +
     ', but the rules denied the read.';
 
@@ -101,7 +106,7 @@ exports.unreadableError = function(result) {
 
 exports.writableError = function(result) {
 
-  var msg = 'Expected ' + getUserDescription(result.auth) +
+  let msg = 'Expected ' + getUserDescription(result.auth) +
     ' not to be able to write ' + JSON.stringify(result.newValue) +
     ' to ' + result.path +
     ', but the rules allowed the write.';
@@ -116,7 +121,7 @@ exports.writableError = function(result) {
 
 exports.unwritableError = function(result) {
 
-  var msg = 'Expected ' + getUserDescription(result.auth) +
+  let msg = 'Expected ' + getUserDescription(result.auth) +
     ' to be able to write ' + JSON.stringify(result.newValue) +
     ' to ' + result.path +
     ', but the rules denied the write.';
@@ -148,7 +153,7 @@ exports.setFirebaseData = function(value, now) {
 
   try {
     value = store.create(value, {now});
-  } catch(e) {
+  } catch (e) {
     db = data = undefined;
     throw new Error('Proposed Firebase data is not valid: ' + e.message);
   }
@@ -172,7 +177,7 @@ exports.setFirebaseRules = function(ruleDefinition) {
 
   try {
     rules = ruleset.create(ruleDefinition);
-  } catch(e) {
+  } catch (e) {
     throw new Error('Proposed Firebase rules are not valid: ' + e.message);
   }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "scripts": {
     "coverage": "istanbul cover node_modules/.bin/_mocha -- --require test/setup.js --recursive -b test/spec/",
-    "lint": "eslint lib/ test/ bin/targaryen",
+    "format": "npm run lint -- --fix",
+    "lint": "eslint lib/ plugins/ test/ bin/targaryen",
+    "lint:html": "(npm run -s lint -- --max-warnings 0 -f html -o lint.html && rm lint.html) || echo 'open lint.html for linting errors'",
     "test": "mocha -r test/setup.js test/spec/ --recursive  && jasmine && node ./bin/targaryen --verbose test/integration/rules.json test/integration/tests.json"
   },
   "author": "Harry Schmidt <me@goldibex.com>",
@@ -51,7 +53,8 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
-    "eslint": "^3.8.1",
+    "eslint": "^3.9.1",
+    "eslint-config-xo": "^0.17.0",
     "eslint-plugin-node": "^2.1.3",
     "istanbul": "^0.4.5",
     "jasmine": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "strip-json-comments": "^2.0.1"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^3.5.0",
+    "dirty-chai": "^1.2.2",
     "eslint": "^3.8.1",
     "eslint-plugin-node": "^2.1.3",
     "istanbul": "^0.4.5",

--- a/plugins/chai.js
+++ b/plugins/chai.js
@@ -3,11 +3,12 @@
  * targaryen.
  *
  */
+
 'use strict';
 
-var targaryen = require('../');
+const targaryen = require('../');
 
-var plugin = function chaiTargaryen(chai, utils) {
+function chaiTargaryen(chai, utils) {
 
   chai.Assertion.addProperty('can', function() {
     utils.flag(this, 'positivity', true);
@@ -59,14 +60,14 @@ var plugin = function chaiTargaryen(chai, utils) {
 
     targaryen.util.assertConfigured();
 
-    var auth = this._obj,
-      data = targaryen.util.getFirebaseData().as(auth),
-      operationType = utils.flag(this, 'operation'),
-      now = utils.flag(this, 'operationTimestamp'),
-      positivity = utils.flag(this, 'positivity'),
-      result, newData;
+    const auth = this._obj;
+    const data = targaryen.util.getFirebaseData().as(auth);
+    const operationType = utils.flag(this, 'operation');
+    const now = utils.flag(this, 'operationTimestamp');
+    const positivity = utils.flag(this, 'positivity');
+    let result, newData;
 
-    switch(operationType) {
+    switch (operationType) {
 
     case 'read':
       result = data.read(path, now);
@@ -101,11 +102,11 @@ var plugin = function chaiTargaryen(chai, utils) {
 
   });
 
-};
+}
 
-plugin.users = targaryen.util.users;
-plugin.setDebug = targaryen.util.setDebug;
-plugin.setFirebaseData = targaryen.util.setFirebaseData;
-plugin.setFirebaseRules = targaryen.util.setFirebaseRules;
+chaiTargaryen.users = targaryen.util.users;
+chaiTargaryen.setDebug = targaryen.util.setDebug;
+chaiTargaryen.setFirebaseData = targaryen.util.setFirebaseData;
+chaiTargaryen.setFirebaseRules = targaryen.util.setFirebaseRules;
 
-module.exports = plugin;
+module.exports = chaiTargaryen;

--- a/plugins/jasmine.js
+++ b/plugins/jasmine.js
@@ -3,9 +3,10 @@
  * targaryen.
  *
  */
+
 'use strict';
 
-var targaryen = require('../');
+const targaryen = require('../');
 
 exports.setFirebaseData = targaryen.util.setFirebaseData;
 exports.setFirebaseRules = targaryen.util.setFirebaseRules;
@@ -14,13 +15,13 @@ exports.users = targaryen.util.users;
 
 exports.matchers = {
 
-  canRead: function() {
+  canRead() {
 
-    return { compare: function(auth, path, now) {
+    return {compare(auth, path, now) {
 
-      var data = targaryen.util.getFirebaseData().as(auth);
+      const data = targaryen.util.getFirebaseData().as(auth);
 
-      var result = data.read(path, now);
+      const result = data.read(path, now);
 
       return {
         pass: result.allowed === true,
@@ -30,13 +31,13 @@ exports.matchers = {
     }};
 
   },
-  cannotRead: function() {
+  cannotRead() {
 
-    return { compare: function(auth, path, now) {
+    return {compare(auth, path, now) {
 
-      var data = targaryen.util.getFirebaseData().as(auth);
+      const data = targaryen.util.getFirebaseData().as(auth);
 
-      var result = data.read(path, now);
+      const result = data.read(path, now);
 
       return {
         pass: result.allowed === false,
@@ -46,13 +47,13 @@ exports.matchers = {
     }};
 
   },
-  canWrite: function() {
+  canWrite() {
 
-    return { compare: function(auth, path, newData, now) {
+    return {compare(auth, path, newData, now) {
 
-      var data = targaryen.util.getFirebaseData().as(auth);
+      const data = targaryen.util.getFirebaseData().as(auth);
 
-      var result = data.write(path, newData, now);
+      const result = data.write(path, newData, now);
 
       return {
         pass: result.allowed === true,
@@ -62,13 +63,13 @@ exports.matchers = {
     }};
 
   },
-  cannotWrite: function() {
+  cannotWrite() {
 
-    return { compare: function(auth, path, newData, now) {
+    return {compare(auth, path, newData, now) {
 
-      var data = targaryen.util.getFirebaseData().as(auth);
+      const data = targaryen.util.getFirebaseData().as(auth);
 
-      var result = data.write(path, newData, now);
+      const result = data.write(path, newData, now);
 
       return {
         pass: result.allowed === false,
@@ -77,13 +78,13 @@ exports.matchers = {
 
     }};
   },
-  canPatch: function() {
+  canPatch() {
 
-    return { compare: function(auth, path, newData, now) {
+    return {compare(auth, path, newData, now) {
 
-      var data = targaryen.util.getFirebaseData().as(auth);
+      const data = targaryen.util.getFirebaseData().as(auth);
 
-      var result = data.update(path, newData, now);
+      const result = data.update(path, newData, now);
 
       return {
         pass: result.allowed === true,
@@ -93,13 +94,13 @@ exports.matchers = {
     }};
 
   },
-  cannotPatch: function() {
+  cannotPatch() {
 
-    return { compare: function(auth, path, newData, now) {
+    return {compare(auth, path, newData, now) {
 
-      var data = targaryen.util.getFirebaseData().as(auth);
+      const data = targaryen.util.getFirebaseData().as(auth);
 
-      var result = data.update(path, newData, now);
+      const result = data.update(path, newData, now);
 
       return {
         pass: result.allowed === false,

--- a/test/jasmine/.eslintrc.yml
+++ b/test/jasmine/.eslintrc.yml
@@ -1,3 +1,6 @@
 extends: '../../.eslintrc.yml'
 env:
   jasmine: true
+rules:
+  prefer-arrow-callback:
+    - "off"

--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -46,7 +46,7 @@ describe('the targaryen Jasmine plugin', function() {
           },
           'password:3403291b-fdc9-4995-9a54-9656241c835d': {
             name: 'John Watson'
-          },
+          }
 
         }
       });
@@ -85,25 +85,25 @@ describe('the targaryen Jasmine plugin', function() {
 
   });
 
-  describe("deep write", function(){
+  describe('deep write', function(){
     beforeEach(function(){
       targaryen.setFirebaseData(
-        { flats: { "221bbakerst": { landlady: 'Mrs Hudson' }  } }
-      )
-        targaryen.setFirebaseRules({
-          "rules": {
-            "flats": {
-              "$cid": {
-                ".validate": "newData.hasChildren(['landlady'])",
-                ".write": "true",
-                ".read": "true"
-              }
+        { flats: { '221bbakerst': { landlady: 'Mrs Hudson' }  } }
+      );
+      targaryen.setFirebaseRules({
+        'rules': {
+          'flats': {
+            '$cid': {
+              '.validate': 'newData.hasChildren([\'landlady\'])',
+              '.write': 'true',
+              '.read': 'true'
             }
           }
-        })
-    })
-    it("should not check parent validations", function(){
-      expect({uid:'holmes'}).canWrite('/flats/221bbakerst/tenants/Holmes',{})
+        }
+      });
+    });
+    it('should not check parent validations', function(){
+      expect({uid:'holmes'}).canWrite('/flats/221bbakerst/tenants/Holmes',{});
     });
   });
 
@@ -170,46 +170,46 @@ describe('the targaryen Jasmine plugin', function() {
       // using double quotes to make the data & rules compatible with Firebase (web interface)
 
       targaryen.setFirebaseData({
-        "users": {
-          "password": {
-            "password:500f6e96-92c6-4f60-ad5d-207253aee4d3": {
-              "name": "Sherlock Holmes"
+        'users': {
+          'password': {
+            'password:500f6e96-92c6-4f60-ad5d-207253aee4d3': {
+              'name': 'Sherlock Holmes'
             },
-            "password:3403291b-fdc9-4995-9a54-9656241c835d": {
-              "name": "John Watson"
-            },
-          },
+            'password:3403291b-fdc9-4995-9a54-9656241c835d': {
+              'name': 'John Watson'
+            }
+          }
         },
-        "first": {
-          "second": {
-            "third": {
-              "any": "value"
+        'first': {
+          'second': {
+            'third': {
+              'any': 'value'
             }
           }
         }
       });
 
       targaryen.setFirebaseRules({
-        "rules": {
-          "users": {
-            "$provider": {
-              "$user": {
+        'rules': {
+          'users': {
+            '$provider': {
+              '$user': {
                 // all data is personal (read and write)
-                ".read": "auth !== null && auth.uid === $user && auth.provider === $provider",
-                ".write": "auth !== null && auth.uid === $user && auth.provider === $provider",
+                '.read': 'auth !== null && auth.uid === $user && auth.provider === $provider',
+                '.write': 'auth !== null && auth.uid === $user && auth.provider === $provider'
               }
             }
           },
-          "posts": {
-            "$post": {
-              ".read": true,
-              ".write": "newData.child('author').val() == auth.uid"
+          'posts': {
+            '$post': {
+              '.read': true,
+              '.write': 'newData.child(\'author\').val() == auth.uid'
             }
           },
-          "$one": {
-            "$two": {
-              "$three": {
-                ".read": "$one == 'first' && $two == 'second' && $three == 'third'"
+          '$one': {
+            '$two': {
+              '$three': {
+                '.read': '$one == \'first\' && $two == \'second\' && $three == \'third\''
               }
             }
           }
@@ -228,91 +228,91 @@ describe('the targaryen Jasmine plugin', function() {
 
   });
 
-  describe("delete nodes", function(){
+  describe('delete nodes', function(){
     beforeEach(function(){
       targaryen.setFirebaseData({
-        "test": {
-          "number": 42,
-          "bool": true
+        'test': {
+          'number': 42,
+          'bool': true
         },
-        "canDelete": "test",
-        "otherCanDelete": "test"
+        'canDelete': 'test',
+        'otherCanDelete': 'test'
       });
       targaryen.setFirebaseRules({
-        "rules": {
-          "test": {
-            ".write": "true",
-            ".read": "true",
-            ".validate": "newData.hasChildren(['number', 'bool'])",
-            "number": {
-              ".validate": "newData.isNumber()"
+        'rules': {
+          'test': {
+            '.write': 'true',
+            '.read': 'true',
+            '.validate': 'newData.hasChildren([\'number\', \'bool\'])',
+            'number': {
+              '.validate': 'newData.isNumber()'
             },
-            "bool": {
-              ".validate": "newData.isBoolean()"
+            'bool': {
+              '.validate': 'newData.isBoolean()'
             }
           },
-          "canDelete": {
-            ".read": "true",
-            ".write": "true",
-            ".validate": "newData.isString()"
+          'canDelete': {
+            '.read': 'true',
+            '.write': 'true',
+            '.validate': 'newData.isString()'
           },
-          "shouldValidate": {
-            ".read": "true",
-            ".write": "true",
-            ".validate": "newData.isBoolean()"
+          'shouldValidate': {
+            '.read': 'true',
+            '.write': 'true',
+            '.validate': 'newData.isBoolean()'
           },
-          "otherCanDelete": {
-            ".read": "true",
-            ".write": "true",
-            ".validate": "newData.isString()"
-          },
+          'otherCanDelete': {
+            '.read': 'true',
+            '.write': 'true',
+            '.validate': 'newData.isString()'
+          }
         }
       });
     });
 
-    it("should not be able to delete /test/number", function(){
+    it('should not be able to delete /test/number', function(){
       expect({uid:'anyone'}).cannotWrite('test/number', null);
     });
 
-    it("should be able to delete /test", function(){
+    it('should be able to delete /test', function(){
       expect({uid:'anyone'}).canWrite('test', null);
     });
 
-    it("should be able to delete /canDelete", function(){
+    it('should be able to delete /canDelete', function(){
       expect({uid:'anyone'}).canWrite('canDelete', null);
     });
 
-    it("should not be able to delete part of /test in a multi-update", function () {
+    it('should not be able to delete part of /test in a multi-update', function () {
       expect({uid:'anyone'}).cannotPatch('/', {
-        "test/bool": null,
-        "canDelete": null
+        'test/bool': null,
+        'canDelete': null
       });
     });
 
-    it("should be able to delete as part of a multi-path write", function () {
+    it('should be able to delete as part of a multi-path write', function () {
       expect({uid:'anyone'}).canPatch('/', {
-        "test": {
-          "bool": false,
-          "number": 5
+        'test': {
+          'bool': false,
+          'number': 5
         },
-        "canDelete": null
+        'canDelete': null
       });
     });
 
-    it("should be able to delete a whole object by nulling all children", function () {
+    it('should be able to delete a whole object by nulling all children', function () {
       expect({uid:'anyone'}).canWrite('test', {
-          "bool": null,
-          "number": null
+        'bool': null,
+        'number': null
       });
 
-      pending("This doesn't work in the tests, but this works at least in the Javascrip SDK");
+      pending('This doesn\'t work in the tests, but this works at least in the Javascrip SDK');
     });
 
     it('should not be able to write invalid data by deleting a sibling', function() {
       expect({uid:'anyone'}).cannotWrite('/', {
-        "canDelete": null,
-        "shouldValidate": "not a boolean",
-        "otherCanDelete": null
+        'canDelete': null,
+        'shouldValidate': 'not a boolean',
+        'otherCanDelete': null
       });
     });
 

--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -1,9 +1,10 @@
 /**
  * Jasmine test definition to test targaryen Jasmine integration.
  */
+
 'use strict';
 
-var targaryen = require('../../plugins/jasmine');
+const targaryen = require('../../plugins/jasmine');
 
 describe('the targaryen Jasmine plugin', function() {
 
@@ -77,23 +78,23 @@ describe('the targaryen Jasmine plugin', function() {
       expect(targaryen.users.unauthenticated).cannotRead('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
 
       expect(targaryen.users.password)
-      .canWrite('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3', { name: 'Sherlock Holmes, Ph.D'});
+      .canWrite('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3', {name: 'Sherlock Holmes, Ph.D'});
       expect(targaryen.users.password)
-      .cannotWrite('posts/newpost', { author: 'password:3403291b-fdc9-4995-9a54-9656241c835d'});
+      .cannotWrite('posts/newpost', {author: 'password:3403291b-fdc9-4995-9a54-9656241c835d'});
 
     });
 
   });
 
-  describe('deep write', function(){
-    beforeEach(function(){
+  describe('deep write', function() {
+    beforeEach(function() {
       targaryen.setFirebaseData(
-        { flats: { '221bbakerst': { landlady: 'Mrs Hudson' }  } }
+        {flats: {'221bbakerst': {landlady: 'Mrs Hudson'}}}
       );
       targaryen.setFirebaseRules({
-        'rules': {
-          'flats': {
-            '$cid': {
+        rules: {
+          flats: {
+            $cid: {
               '.validate': 'newData.hasChildren([\'landlady\'])',
               '.write': 'true',
               '.read': 'true'
@@ -102,8 +103,8 @@ describe('the targaryen Jasmine plugin', function() {
         }
       });
     });
-    it('should not check parent validations', function(){
-      expect({uid:'holmes'}).canWrite('/flats/221bbakerst/tenants/Holmes',{});
+    it('should not check parent validations', function() {
+      expect({uid: 'holmes'}).canWrite('/flats/221bbakerst/tenants/Holmes', {});
     });
   });
 
@@ -130,13 +131,13 @@ describe('the targaryen Jasmine plugin', function() {
       targaryen.setFirebaseRules({
         rules: {
           users: {
-            '$user': {
+            $user: {
               '.read': 'auth.uid === $user',
               '.write': 'auth.isSuper === true'
             }
           },
           posts: {
-            '$post': {
+            $post: {
               '.read': true,
               '.write': true,
               '.validate': 'newData.hasChildren(["created", "text", "author"]) && newData.child("author").val() === auth.uid',
@@ -152,14 +153,14 @@ describe('the targaryen Jasmine plugin', function() {
       });
     });
     it('should test a patch operation is allowed', function() {
-      expect({uid:'some-provider:1'}).canPatch('/posts/somePost', {
-        'text': 'Hello World!'
+      expect({uid: 'some-provider:1'}).canPatch('/posts/somePost', {
+        text: 'Hello World!'
       });
     });
     it('should test a patch operation is not allowed', function() {
-      expect({uid:'some-provider:1'}).cannotPatch('/posts/somePost', {
-        'text': 'Hello World!',
-        'created': Date.now()
+      expect({uid: 'some-provider:1'}).cannotPatch('/posts/somePost', {
+        text: 'Hello World!',
+        created: Date.now()
       });
     });
   });
@@ -170,45 +171,45 @@ describe('the targaryen Jasmine plugin', function() {
       // using double quotes to make the data & rules compatible with Firebase (web interface)
 
       targaryen.setFirebaseData({
-        'users': {
-          'password': {
+        users: {
+          password: {
             'password:500f6e96-92c6-4f60-ad5d-207253aee4d3': {
-              'name': 'Sherlock Holmes'
+              name: 'Sherlock Holmes'
             },
             'password:3403291b-fdc9-4995-9a54-9656241c835d': {
-              'name': 'John Watson'
+              name: 'John Watson'
             }
           }
         },
-        'first': {
-          'second': {
-            'third': {
-              'any': 'value'
+        first: {
+          second: {
+            third: {
+              any: 'value'
             }
           }
         }
       });
 
       targaryen.setFirebaseRules({
-        'rules': {
-          'users': {
-            '$provider': {
-              '$user': {
+        rules: {
+          users: {
+            $provider: {
+              $user: {
                 // all data is personal (read and write)
                 '.read': 'auth !== null && auth.uid === $user && auth.provider === $provider',
                 '.write': 'auth !== null && auth.uid === $user && auth.provider === $provider'
               }
             }
           },
-          'posts': {
-            '$post': {
+          posts: {
+            $post: {
               '.read': true,
               '.write': 'newData.child(\'author\').val() == auth.uid'
             }
           },
-          '$one': {
-            '$two': {
-              '$three': {
+          $one: {
+            $two: {
+              $three: {
                 '.read': '$one == \'first\' && $two == \'second\' && $three == \'third\''
               }
             }
@@ -228,40 +229,40 @@ describe('the targaryen Jasmine plugin', function() {
 
   });
 
-  describe('delete nodes', function(){
-    beforeEach(function(){
+  describe('delete nodes', function() {
+    beforeEach(function() {
       targaryen.setFirebaseData({
-        'test': {
-          'number': 42,
-          'bool': true
+        test: {
+          number: 42,
+          bool: true
         },
-        'canDelete': 'test',
-        'otherCanDelete': 'test'
+        canDelete: 'test',
+        otherCanDelete: 'test'
       });
       targaryen.setFirebaseRules({
-        'rules': {
-          'test': {
+        rules: {
+          test: {
             '.write': 'true',
             '.read': 'true',
             '.validate': 'newData.hasChildren([\'number\', \'bool\'])',
-            'number': {
+            number: {
               '.validate': 'newData.isNumber()'
             },
-            'bool': {
+            bool: {
               '.validate': 'newData.isBoolean()'
             }
           },
-          'canDelete': {
+          canDelete: {
             '.read': 'true',
             '.write': 'true',
             '.validate': 'newData.isString()'
           },
-          'shouldValidate': {
+          shouldValidate: {
             '.read': 'true',
             '.write': 'true',
             '.validate': 'newData.isBoolean()'
           },
-          'otherCanDelete': {
+          otherCanDelete: {
             '.read': 'true',
             '.write': 'true',
             '.validate': 'newData.isString()'
@@ -270,49 +271,49 @@ describe('the targaryen Jasmine plugin', function() {
       });
     });
 
-    it('should not be able to delete /test/number', function(){
-      expect({uid:'anyone'}).cannotWrite('test/number', null);
+    it('should not be able to delete /test/number', function() {
+      expect({uid: 'anyone'}).cannotWrite('test/number', null);
     });
 
-    it('should be able to delete /test', function(){
-      expect({uid:'anyone'}).canWrite('test', null);
+    it('should be able to delete /test', function() {
+      expect({uid: 'anyone'}).canWrite('test', null);
     });
 
-    it('should be able to delete /canDelete', function(){
-      expect({uid:'anyone'}).canWrite('canDelete', null);
+    it('should be able to delete /canDelete', function() {
+      expect({uid: 'anyone'}).canWrite('canDelete', null);
     });
 
-    it('should not be able to delete part of /test in a multi-update', function () {
-      expect({uid:'anyone'}).cannotPatch('/', {
+    it('should not be able to delete part of /test in a multi-update', function() {
+      expect({uid: 'anyone'}).cannotPatch('/', {
         'test/bool': null,
-        'canDelete': null
+        canDelete: null
       });
     });
 
-    it('should be able to delete as part of a multi-path write', function () {
-      expect({uid:'anyone'}).canPatch('/', {
-        'test': {
-          'bool': false,
-          'number': 5
+    it('should be able to delete as part of a multi-path write', function() {
+      expect({uid: 'anyone'}).canPatch('/', {
+        test: {
+          bool: false,
+          number: 5
         },
-        'canDelete': null
+        canDelete: null
       });
     });
 
-    it('should be able to delete a whole object by nulling all children', function () {
-      expect({uid:'anyone'}).canWrite('test', {
-        'bool': null,
-        'number': null
+    it('should be able to delete a whole object by nulling all children', function() {
+      expect({uid: 'anyone'}).canWrite('test', {
+        bool: null,
+        number: null
       });
 
       pending('This doesn\'t work in the tests, but this works at least in the Javascrip SDK');
     });
 
     it('should not be able to write invalid data by deleting a sibling', function() {
-      expect({uid:'anyone'}).cannotWrite('/', {
-        'canDelete': null,
-        'shouldValidate': 'not a boolean',
-        'otherCanDelete': null
+      expect({uid: 'anyone'}).cannotWrite('/', {
+        canDelete: null,
+        shouldValidate: 'not a boolean',
+        otherCanDelete: null
       });
     });
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -10,8 +10,10 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
+const dirtyChai = require('dirty-chai');
 
 chai.use(sinonChai);
+chai.use(dirtyChai);
 
 global.expect = chai.expect;
 global.sinon = sinon;

--- a/test/setup.js
+++ b/test/setup.js
@@ -5,6 +5,7 @@
  * test are loaded or run.
  *
  */
+
 'use strict';
 
 const chai = require('chai');

--- a/test/spec/.eslintrc.yml
+++ b/test/spec/.eslintrc.yml
@@ -4,3 +4,7 @@ env:
 globals:
   expect: true
   sinon: true
+rules:
+  max-nested-callbacks: "off"
+  no-new: "off"
+  prefer-arrow-callback: "off"

--- a/test/spec/lib/database.js
+++ b/test/spec/lib/database.js
@@ -225,7 +225,7 @@ describe('database', function() {
       });
 
       it('returns null if we are at the top', function() {
-        expect(root.parent()).to.be.null;
+        expect(root.parent()).to.be.null();
       });
 
     });
@@ -233,11 +233,11 @@ describe('database', function() {
     describe('#exists', function() {
 
       it('returns true if some data is at that key', function() {
-        expect(root.child('users').exists()).to.be.true;
+        expect(root.child('users').exists()).to.be.true();
       });
 
       it('returns false if no data is at that key', function() {
-        expect(root.child('nonexistent').exists()).to.be.false;
+        expect(root.child('nonexistent').exists()).to.be.false();
       });
 
     });
@@ -245,11 +245,11 @@ describe('database', function() {
     describe('#hasChild', function() {
 
       it('returns true if the path has a child with the given name', function() {
-        expect(root.hasChild('users')).to.be.true;
+        expect(root.hasChild('users')).to.be.true();
       });
 
       it('returns false if the path does not have a child with the given name', function() {
-        expect(root.hasChild('nonexistent')).to.be.false;
+        expect(root.hasChild('nonexistent')).to.be.false();
       });
 
     });
@@ -263,7 +263,7 @@ describe('database', function() {
             root
               .child('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3')
               .hasChildren()
-          ).to.be.true;
+          ).to.be.true();
         });
 
         it('returns false if the path has no children', function() {
@@ -271,7 +271,7 @@ describe('database', function() {
             root
               .child('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/name')
               .hasChildren()
-          ).to.be.false;
+          ).to.be.false();
         });
 
       });
@@ -292,7 +292,7 @@ describe('database', function() {
             root
               .child('users/password:c7ec6752-45b3-404f-a2b9-7df07b78d28e')
               .hasChildren(['name', 'genius', 'arrests'])
-          ).to.be.true;
+          ).to.be.true();
 
         });
 
@@ -301,7 +301,7 @@ describe('database', function() {
             root
               .child('users/password:3403291b-fdc9-4995-9a54-9656241c835d')
               .hasChildren(['name', 'genius', 'arrests'])
-          ).to.be.false;
+          ).to.be.false();
         });
 
       });
@@ -315,7 +315,7 @@ describe('database', function() {
           root
             .child('users/password:3403291b-fdc9-4995-9a54-9656241c835d/arrests')
             .isNumber()
-        ).to.be.true;
+        ).to.be.true();
       });
 
       it('returns false if the value at the path does not have type number', function() {
@@ -323,7 +323,7 @@ describe('database', function() {
           root
             .child('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/arrests')
             .isNumber()
-        ).to.be.false;
+        ).to.be.false();
       });
 
     });
@@ -335,7 +335,7 @@ describe('database', function() {
           root
             .child('users/password:c7ec6752-45b3-404f-a2b9-7df07b78d28e/genius')
             .isBoolean()
-        ).to.be.true;
+        ).to.be.true();
       });
 
       it('returns false if the value at the path does not have type boolean', function() {
@@ -343,7 +343,7 @@ describe('database', function() {
           root
             .child('users/password:3403291b-fdc9-4995-9a54-9656241c835d/name')
             .isBoolean()
-        ).to.be.false;
+        ).to.be.false();
       });
 
     });
@@ -355,7 +355,7 @@ describe('database', function() {
           root
             .child('users/password:3403291b-fdc9-4995-9a54-9656241c835d/name')
             .isString()
-        ).to.be.true;
+        ).to.be.true();
       });
 
       it('returns false if the value at the path does not have type string', function() {
@@ -363,7 +363,7 @@ describe('database', function() {
           root
             .child('users/password:3403291b-fdc9-4995-9a54-9656241c835d')
             .isString()
-        ).to.be.false;
+        ).to.be.false();
       });
 
     });
@@ -438,15 +438,15 @@ describe('database', function() {
 
     it('returns the result of attempting to read the given path with the given DB state', function() {
 
-      expect(db.read('foo/firstChild/baz').allowed).to.be.true;
-      expect(db.read('foo/secondChild/baz').allowed).to.be.false;
+      expect(db.read('foo/firstChild/baz').allowed).to.be.true();
+      expect(db.read('foo/secondChild/baz').allowed).to.be.false();
 
     });
 
     it('should propagate variables in path', function() {
 
-      expect(db.read('nested/one/two').allowed).to.be.false;
-      expect(db.read('nested/one/one').allowed).to.be.true;
+      expect(db.read('nested/one/two').allowed).to.be.false();
+      expect(db.read('nested/one/one').allowed).to.be.true();
 
     });
 
@@ -526,7 +526,7 @@ describe('database', function() {
 
       db = database.create(rules, {'a': 1});
 
-      expect(db.read('/a').allowed).to.be.false;
+      expect(db.read('/a').allowed).to.be.false();
     });
 
   });
@@ -543,7 +543,7 @@ describe('database', function() {
 
       const newData = {'.sv': 'timestamp'};
 
-      expect(db.write('timestamp/foo', newData).allowed).to.be.true;
+      expect(db.write('timestamp/foo', newData).allowed).to.be.true();
 
     });
 
@@ -551,16 +551,16 @@ describe('database', function() {
 
       const newData = {'wut': {'.value': true}};
 
-      expect(db.write('foo/firstChild', newData).allowed).to.be.false;
-      expect(db.as(superAuth).write('foo/firstChild', newData).allowed).to.be.true;
+      expect(db.write('foo/firstChild', newData).allowed).to.be.false();
+      expect(db.as(superAuth).write('foo/firstChild', newData).allowed).to.be.true();
 
     });
 
     it('should propagate variables in path', function() {
 
-      expect(db.write('nested/one/two', {id: 'two'}).allowed).to.be.false;
-      expect(db.write('nested/one/one', {id: 'one'}).allowed).to.be.true;
-      expect(db.write('nested/one/one', {id: 'two'}).allowed).to.be.false;
+      expect(db.write('nested/one/two', {id: 'two'}).allowed).to.be.false();
+      expect(db.write('nested/one/one', {id: 'one'}).allowed).to.be.true();
+      expect(db.write('nested/one/one', {id: 'two'}).allowed).to.be.false();
 
     });
 
@@ -586,10 +586,10 @@ describe('database', function() {
       const result = db.write('/a/b', null);
 
       expect(result.newRoot.val()).to.be.deep.equal(null);
-      expect(result.newRoot.child('a').val()).to.be.null;
-      expect(result.newRoot.child('a').exists()).to.be.false;
-      expect(result.newRoot.val()).to.be.null;
-      expect(result.newRoot.exists()).to.be.false;
+      expect(result.newRoot.child('a').val()).to.be.null();
+      expect(result.newRoot.child('a').exists()).to.be.false();
+      expect(result.newRoot.val()).to.be.null();
+      expect(result.newRoot.exists()).to.be.false();
 
     });
 
@@ -600,14 +600,14 @@ describe('database', function() {
       });
 
       expect(result.newData.val()).to.eql({type: 'b', b: 1});
-      expect(result.allowed).to.be.true;
+      expect(result.allowed).to.be.true();
 
       result = db.write('mixedType/first', {
         type: {'.value': 'a'},
         b: {'.value': 1}
       });
 
-      expect(result.allowed).to.be.false;
+      expect(result.allowed).to.be.false();
     });
 
     it('should traverse all write rules', function() {
@@ -820,7 +820,7 @@ describe('database', function() {
 
       db = database.create(rules, {'a': 1});
 
-      expect(db.write('/a', 2).allowed).to.be.false;
+      expect(db.write('/a', 2).allowed).to.be.false();
     });
 
     it('should fail on error in validate rules evaluation', function() {
@@ -835,7 +835,7 @@ describe('database', function() {
 
       db = database.create(rules, {'a': 1});
 
-      expect(db.write('/a', 2).allowed).to.be.false;
+      expect(db.write('/a', 2).allowed).to.be.false();
     });
 
   });
@@ -905,7 +905,7 @@ describe('database', function() {
               foo: {
                 '.value': 1
               }
-            },
+            }
           }
         }
       };
@@ -922,10 +922,10 @@ describe('database', function() {
         'timestamps/baz': 12345000
       };
 
-      expect(db.update('/', newData).allowed).to.be.false;
+      expect(db.update('/', newData).allowed).to.be.false();
       delete newData['timestamps/baz'];
 
-      expect(db.update('/', newData).allowed).to.be.true;
+      expect(db.update('/', newData).allowed).to.be.true();
     });
 
     it('should allow validate write', function() {
@@ -934,22 +934,22 @@ describe('database', function() {
         'foo/fooz': false
       };
 
-      expect(db.as(auth).update('/', newData).allowed).to.be.true;
-      expect(db.update('/', newData).allowed).to.be.false;
+      expect(db.as(auth).update('/', newData).allowed).to.be.true();
+      expect(db.update('/', newData).allowed).to.be.false();
 
       newData['foo/bar'] = false;
-      expect(db.as(auth).update('/', newData).allowed).to.be.false;
+      expect(db.as(auth).update('/', newData).allowed).to.be.false();
     });
 
     it('should propagate variables in path', function() {
-      expect(db.as(auth).update('nested/one/one', {foo: 2}).allowed).to.be.true;
-      expect(db.as(auth).update('nested/one/two', {foo: 2}).allowed).to.be.false;
+      expect(db.as(auth).update('nested/one/one', {foo: 2}).allowed).to.be.true();
+      expect(db.as(auth).update('nested/one/two', {foo: 2}).allowed).to.be.false();
     });
 
     it('should handle empty patch', function() {
       const result = db.as(auth).update('nested/one/one', {});
 
-      expect(result.allowed).to.be.true;
+      expect(result.allowed).to.be.true();
       expect(result.newData.val()).to.eql({foo: 1});
     });
 
@@ -963,10 +963,10 @@ describe('database', function() {
       const result = db.update('/', {'/a/b': {}});
 
       expect(result.newRoot.val()).to.be.deep.equal(null);
-      expect(result.newRoot.child('a').val()).to.be.null;
-      expect(result.newRoot.child('a').exists()).to.be.false;
-      expect(result.newRoot.val()).to.be.null;
-      expect(result.newRoot.exists()).to.be.false;
+      expect(result.newRoot.child('a').val()).to.be.null();
+      expect(result.newRoot.child('a').exists()).to.be.false();
+      expect(result.newRoot.val()).to.be.null();
+      expect(result.newRoot.exists()).to.be.false();
 
     });
 
@@ -981,7 +981,7 @@ describe('database', function() {
 
       db = database.create(rules, {'a': 1});
 
-      expect(db.update('/', {a: 2}).allowed).to.be.false;
+      expect(db.update('/', {a: 2}).allowed).to.be.false();
     });
 
     it('should fail on error in validate rules evaluation', function() {
@@ -996,7 +996,7 @@ describe('database', function() {
 
       db = database.create(rules, {'a': 1});
 
-      expect(db.update('/', {a: 2}).allowed).to.be.false;
+      expect(db.update('/', {a: 2}).allowed).to.be.false();
     });
 
   });

--- a/test/spec/lib/database.js
+++ b/test/spec/lib/database.js
@@ -8,6 +8,7 @@
  * "test/spec/lib/parser/rule.js".
  *
  */
+
 'use strict';
 
 const database = require('../../../lib/database');
@@ -20,7 +21,7 @@ function getRuleset() {
       foo: {
         '.read': false,
         '.write': false,
-        '$bar': {
+        $bar: {
           '.read': 'auth !== null',
           '.write': 'auth.id === 1',
           baz: {
@@ -69,34 +70,34 @@ function getDB() {
 
   const rules = getRuleset();
   const initialData = {
-    'foo': {
-      'firstChild': {
+    foo: {
+      firstChild: {
         '.priority': 0,
         baz: {
           '.value': true
         }
       },
-      'secondChild': {
+      secondChild: {
         '.priority': 1,
         baz: {
           '.value': false
         }
       }
     },
-    'nested': {
-      'one': {
-        'one': {id: {'.value': 'one'}},
-        'two': {id: {'.value': 'two'}}
+    nested: {
+      one: {
+        one: {id: {'.value': 'one'}},
+        two: {id: {'.value': 'two'}}
       }
     },
-    'mixedType': {
-      'first': {
+    mixedType: {
+      first: {
         type: {'.value': 'a'},
         a: {'.value': 1}
       }
     },
-    'users': {
-      'firstChild': {
+    users: {
+      firstChild: {
         '.value': true
       }
     }
@@ -139,18 +140,18 @@ describe('database', function() {
         users: {
           'password:c7ec6752-45b3-404f-a2b9-7df07b78d28e': {
             '.priority': 1,
-            name: { '.value': 'Sherlock Holmes' },
-            genius: { '.value': true },
-            arrests: { '.value': 70 }
+            name: {'.value': 'Sherlock Holmes'},
+            genius: {'.value': true},
+            arrests: {'.value': 70}
           },
           'password:500f6e96-92c6-4f60-ad5d-207253aee4d3': {
             '.priority': 2,
-            name: { '.value': 'John Watson' }
+            name: {'.value': 'John Watson'}
           },
           'password:3403291b-fdc9-4995-9a54-9656241c835d': {
             '.priority': 0,
-            name: { '.value': 'Inspector Lestrade'},
-            arrests: { '.value': 35 }
+            name: {'.value': 'Inspector Lestrade'},
+            arrests: {'.value': 35}
           },
           'password:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx': {
             '.priority': 0,
@@ -180,9 +181,9 @@ describe('database', function() {
 
         expect(root.val()).to.deep.equal({
           users: {
-            'password:c7ec6752-45b3-404f-a2b9-7df07b78d28e': { name: 'Sherlock Holmes', genius: true, arrests: 70 },
-            'password:500f6e96-92c6-4f60-ad5d-207253aee4d3': { name: 'John Watson' },
-            'password:3403291b-fdc9-4995-9a54-9656241c835d': { name: 'Inspector Lestrade', arrests: 35 }
+            'password:c7ec6752-45b3-404f-a2b9-7df07b78d28e': {name: 'Sherlock Holmes', genius: true, arrests: 70},
+            'password:500f6e96-92c6-4f60-ad5d-207253aee4d3': {name: 'John Watson'},
+            'password:3403291b-fdc9-4995-9a54-9656241c835d': {name: 'Inspector Lestrade', arrests: 35}
           }
         });
 
@@ -402,7 +403,9 @@ describe('database', function() {
     it('should yield each child nodes as a snapshot', function() {
       const snaps = [];
 
-      data.walk('b', s => {snaps.push(s.toString());});
+      data.walk('b', s => {
+        snaps.push(s.toString());
+      });
 
       expect(snaps.sort()).to.eql(['b/c', 'b/d', 'b/d/e', 'b/d/e/f']);
     });
@@ -410,7 +413,9 @@ describe('database', function() {
     it('should yield nodes in descending order', function() {
       const snaps = [];
 
-      data.walk('b/d', s => {snaps.push(s.toString());});
+      data.walk('b/d', s => {
+        snaps.push(s.toString());
+      });
 
       expect(snaps).to.eql(['b/d/e', 'b/d/e/f']);
     });
@@ -524,7 +529,7 @@ describe('database', function() {
         }
       };
 
-      db = database.create(rules, {'a': 1});
+      db = database.create(rules, {a: 1});
 
       expect(db.read('/a').allowed).to.be.false();
     });
@@ -549,7 +554,7 @@ describe('database', function() {
 
     it('returns the result of attempting to write the given path with the given DB state and new data', function() {
 
-      const newData = {'wut': {'.value': true}};
+      const newData = {wut: {'.value': true}};
 
       expect(db.write('foo/firstChild', newData).allowed).to.be.false();
       expect(db.as(superAuth).write('foo/firstChild', newData).allowed).to.be.true();
@@ -564,21 +569,21 @@ describe('database', function() {
 
     });
 
-    it('should prune null keys', function(){
+    it('should prune null keys', function() {
 
-      const value = {'a': 1, 'b': 2};
+      const value = {a: 1, b: 2};
       const rules = {rules: {'.write': true}};
 
       db = database.create(rules, value);
 
-      expect(db.write('/a', null).newRoot.val()).to.be.deep.equal({'b': 2});
-      expect(db.write('/', {'a': 1, 'b': {}}).newRoot.val()).to.be.deep.equal({'a': 1});
+      expect(db.write('/a', null).newRoot.val()).to.be.deep.equal({b: 2});
+      expect(db.write('/', {a: 1, b: {}}).newRoot.val()).to.be.deep.equal({a: 1});
 
     });
 
-    it('should prune null keys deeply', function(){
+    it('should prune null keys deeply', function() {
 
-      const value = {'a': {'b': 2}};
+      const value = {a: {b: 2}};
       const rules = {rules: {'.write': true}};
 
       db = database.create(rules, value);
@@ -620,7 +625,7 @@ describe('database', function() {
               '.write': 'false',
               $c: {
                 '.write': 'false',
-                'd': {
+                d: {
                   '.write': 'false'
                 }
               }
@@ -631,7 +636,7 @@ describe('database', function() {
 
       db = database.create(rules, null);
 
-      let result = db.write('foo/bar/baz', true);
+      const result = db.write('foo/bar/baz', true);
 
       expect(result.logs.map(r => r.path)).to.eql([
         '',
@@ -656,7 +661,7 @@ describe('database', function() {
 
       db = database.create(rules, null);
 
-      let result = db.write('foo/bar/baz', true);
+      const result = db.write('foo/bar/baz', true);
 
       expect(result.logs.map(r => r.path)).to.eql(['', 'foo']);
     });
@@ -679,7 +684,7 @@ describe('database', function() {
 
       db = database.create(rules, null);
 
-      let result = db.write('foo/bar/baz', true);
+      const result = db.write('foo/bar/baz', true);
 
       expect(result.logs.map(r => r.path)).to.eql(['', 'foo/bar/baz']);
     });
@@ -712,7 +717,7 @@ describe('database', function() {
 
       db = database.create(rules, null);
 
-      let result = db.write('foo/bar/baz', {d: true, e: {f: true}});
+      const result = db.write('foo/bar/baz', {d: true, e: {f: true}});
 
       expect(result.logs.filter(r => r.kind === 'validate').map(r => r.path)).to.eql([
         '',
@@ -751,7 +756,7 @@ describe('database', function() {
 
       db = database.create(rules, null);
 
-      let result = db.write('foo/bar/baz', {d: true, e: {f: true}});
+      const result = db.write('foo/bar/baz', {d: true, e: {f: true}});
 
       expect(result.logs.filter(r => r.kind === 'validate').map(r => r.path)).to.eql([
         'foo/bar/baz/d',
@@ -782,7 +787,7 @@ describe('database', function() {
 
       db = database.create(rules, null);
 
-      let result = db.write('foo/bar/baz', {d: true});
+      const result = db.write('foo/bar/baz', {d: true});
 
       expect(result.logs.filter(r => r.kind === 'validate').map(r => r.path)).to.eql(['foo/bar/baz/d']);
     });
@@ -804,7 +809,7 @@ describe('database', function() {
 
       db = database.create(rules, null);
 
-      let result = db.write('foo/bar/baz', null);
+      const result = db.write('foo/bar/baz', null);
 
       expect(result.logs.map(r => r.path)).to.eql(['foo']);
     });
@@ -818,7 +823,7 @@ describe('database', function() {
         }
       };
 
-      db = database.create(rules, {'a': 1});
+      db = database.create(rules, {a: 1});
 
       expect(db.write('/a', 2).allowed).to.be.false();
     });
@@ -833,7 +838,7 @@ describe('database', function() {
         }
       };
 
-      db = database.create(rules, {'a': 1});
+      db = database.create(rules, {a: 1});
 
       expect(db.write('/a', 2).allowed).to.be.false();
     });
@@ -929,7 +934,7 @@ describe('database', function() {
     });
 
     it('should allow validate write', function() {
-      var newData = {
+      const newData = {
         'foo/baz': false,
         'foo/fooz': false
       };
@@ -953,9 +958,9 @@ describe('database', function() {
       expect(result.newData.val()).to.eql({foo: 1});
     });
 
-    it('should prune null keys deeply', function(){
+    it('should prune null keys deeply', function() {
 
-      const value = {'a': {'b': 2}};
+      const value = {a: {b: 2}};
       const rules = {rules: {'.write': true}};
 
       db = database.create(rules, value);
@@ -979,7 +984,7 @@ describe('database', function() {
         }
       };
 
-      db = database.create(rules, {'a': 1});
+      db = database.create(rules, {a: 1});
 
       expect(db.update('/', {a: 2}).allowed).to.be.false();
     });
@@ -994,12 +999,11 @@ describe('database', function() {
         }
       };
 
-      db = database.create(rules, {'a': 1});
+      db = database.create(rules, {a: 1});
 
       expect(db.update('/', {a: 2}).allowed).to.be.false();
     });
 
   });
-
 
 });

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -77,7 +77,7 @@ var ruleEvaluationTests = [{
 }, {
   rule: 'auth.dreams.length > 1 ? false : true',
   wildchildren: [],
-  scope: { auth: { dreams: 'really do',  } },
+  scope: { auth: { dreams: 'really do'  } },
   result: false
 }, {
   rule: '!(auth.dreams.length > 1)',

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -1,13 +1,14 @@
 /**
  * Test firebase rule parsing and evaluation.
  */
+
 'use strict';
 
 const Rule = require('../../../../lib/parser/rule');
 const database = require('../../../../lib/database');
 
-var testWildchildren = ['$here', '$there'];
-var validRules = [
+const testWildchildren = ['$here', '$there'];
+const validRules = [
   'true',
   'false',
   'auth !== null',
@@ -30,7 +31,7 @@ var validRules = [
   'root.child("users/"+auth.uid).exists()',
   'root.child(auth.x+auth.y).exists()'
 ];
-var invalidRules = [
+const invalidRules = [
   'var foo = 8', // invalid syntax (no declarations allowed)
   'root = 5', // invalid syntax (no assignments allowed)
   'auth.uid === "5"; auth.id === 5', // invalid syntax (2 statements)
@@ -49,15 +50,15 @@ var invalidRules = [
   'root.val().notFound == false' // val only returns primitives.
 ];
 
-var ruleEvaluationTests = [{
+const ruleEvaluationTests = [{
   rule: '$skies == "blue"',
   wildchildren: ['$skies'],
-  scope: { $skies: 'blue' },
+  scope: {$skies: 'blue'},
   result: true
 }, {
   rule: '$skies == "green"',
   wildchildren: ['$skies'],
-  scope: { $skies: 'orange' },
+  scope: {$skies: 'orange'},
   result: false
 }, {
   rule: '$skies == "red"',
@@ -67,58 +68,58 @@ var ruleEvaluationTests = [{
 }, {
   rule: '$skies == "blue" && auth.dreams == true',
   wildchildren: ['$skies'],
-  scope: { $skies: 'blue', auth: { dreams: true } },
+  scope: {$skies: 'blue', auth: {dreams: true}},
   result: true
 }, {
   rule: 'auth.dreams.length > 1',
   wildchildren: [],
-  scope: { auth: { dreams: 'really do' } },
+  scope: {auth: {dreams: 'really do'}},
   result: true
 }, {
   rule: 'auth.dreams.length > 1 ? false : true',
   wildchildren: [],
-  scope: { auth: { dreams: 'really do'  } },
+  scope: {auth: {dreams: 'really do'}},
   result: false
 }, {
   rule: '!(auth.dreams.length > 1)',
   wildchildren: [],
-  scope: { auth: { dreams: 'really do' } },
+  scope: {auth: {dreams: 'really do'}},
   result: false
 }, {
   rule: 'root.val() == "bar"',
   wildchildren: [],
-  scope: { root: database.snapshot('/', { '.value': 'bar' }) },
+  scope: {root: database.snapshot('/', {'.value': 'bar'})},
   result: true
 }, {
   rule: 'root.val().contains("ba")',
   wildchildren: [],
-  scope: { root: database.snapshot('/', { '.value': 'bar' }) },
+  scope: {root: database.snapshot('/', {'.value': 'bar'})},
   result: true
 }, {
   rule: 'root.val().matches(/^ba/)',
   wildchildren: [],
-  scope: { root: database.snapshot('/', { '.value': 'bar' }) },
+  scope: {root: database.snapshot('/', {'.value': 'bar'})},
   result: true
 }, {
   rule: 'root.val().matches(/^wa/)',
   wildchildren: [],
-  scope: { root: database.snapshot('/', { '.value': 'bar' }) },
+  scope: {root: database.snapshot('/', {'.value': 'bar'})},
   result: false
 }, {
   rule: 'root.isNumber()',
   wildchildren: [],
-  scope: { root: database.snapshot('/', { '.value': null }) },
+  scope: {root: database.snapshot('/', {'.value': null})},
   result: true,
   skipOnNoValue: true
 }, {
   rule: 'root.isString()',
   wildchildren: [],
-  scope: { root: database.snapshot('/', { '.value': null }) },
+  scope: {root: database.snapshot('/', {'.value': null})},
   result: false
 }, {
   rule: 'auth.foo[$bar] == true',
   wildchildren: ['$bar'],
-  scope: { $bar: 'baz', auth: {foo: {baz: true}}},
+  scope: {$bar: 'baz', auth: {foo: {baz: true}}},
   result: true
 }, {
   rule: 'auth.foo["baz"] == true',
@@ -176,13 +177,15 @@ describe('Rule', function() {
         if (ruleTest.willThrow) {
 
           expect(function() {
-            var rule = new Rule(ruleTest.rule, ruleTest.wildchildren);
+            const rule = new Rule(ruleTest.rule, ruleTest.wildchildren);
+
             rule.evaluate(ruleTest.scope, ruleTest.skipOnNoValue);
           }).to.throw();
 
         } else {
 
-          var rule = new Rule(ruleTest.rule, ruleTest.wildchildren);
+          const rule = new Rule(ruleTest.rule, ruleTest.wildchildren);
+
           expect(rule.evaluate(ruleTest.scope, ruleTest.skipOnNoValue), ruleTest.rule)
           .to.equal(ruleTest.result);
 

--- a/test/spec/lib/parser/string-methods.js
+++ b/test/spec/lib/parser/string-methods.js
@@ -1,9 +1,10 @@
 /**
  * Test firebase string methods.
  */
+
 'use strict';
 
-var stringMethods = require('../../../../lib/parser/string-methods');
+const stringMethods = require('../../../../lib/parser/string-methods');
 
 describe('stringMethods', function() {
 

--- a/test/spec/lib/parser/string-methods.js
+++ b/test/spec/lib/parser/string-methods.js
@@ -10,11 +10,11 @@ describe('stringMethods', function() {
   describe('contains', function() {
 
     it('returns true if the given string contains the given substring', function() {
-      expect(stringMethods.contains('bar', 'ar')).to.be.true;
+      expect(stringMethods.contains('bar', 'ar')).to.be.true();
     });
 
     it('returns false if the given string does not contain the given substring', function() {
-      expect(stringMethods.contains('bar', 'war')).to.be.false;
+      expect(stringMethods.contains('bar', 'war')).to.be.false();
     });
 
   });
@@ -22,11 +22,11 @@ describe('stringMethods', function() {
   describe('beginsWith', function() {
 
     it('returns true if the given string begins with the given substring', function() {
-      expect(stringMethods.beginsWith('bar', 'ba')).to.be.true;
+      expect(stringMethods.beginsWith('bar', 'ba')).to.be.true();
     });
 
     it('returns false if the given string does not begin with the given substring', function() {
-      expect(stringMethods.beginsWith('bar', 'wa')).to.be.false;
+      expect(stringMethods.beginsWith('bar', 'wa')).to.be.false();
     });
 
   });
@@ -34,11 +34,11 @@ describe('stringMethods', function() {
   describe('endsWith', function() {
 
     it('returns true if the given string ends with the given substring', function() {
-      expect(stringMethods.endsWith('bar', 'ar')).to.be.true;
+      expect(stringMethods.endsWith('bar', 'ar')).to.be.true();
     });
 
     it('returns false if the given string does not end with the given substring', function() {
-      expect(stringMethods.endsWith('bar', 'az')).to.be.false;
+      expect(stringMethods.endsWith('bar', 'az')).to.be.false();
     });
 
   });
@@ -54,11 +54,11 @@ describe('stringMethods', function() {
   describe('matches', function() {
 
     it('returns true if the given string matches the given regex', function() {
-      expect(stringMethods.matches('bar', /^ba/)).to.be.true;
+      expect(stringMethods.matches('bar', /^ba/)).to.be.true();
     });
 
     it('returns false if the given string does not match the given regex', function() {
-      expect(stringMethods.matches('bar', /^wa/)).to.be.false;
+      expect(stringMethods.matches('bar', /^wa/)).to.be.false();
     });
 
   });

--- a/test/spec/lib/paths.js
+++ b/test/spec/lib/paths.js
@@ -1,6 +1,7 @@
 /**
  * Test path helper functions.
  */
+
 'use strict';
 
 const paths = require('../../../lib/paths.js');
@@ -34,7 +35,6 @@ describe('paths', function() {
     it('should no split empty path', function() {
       expect(paths.split('')).to.eql([]);
     });
-
 
     it('should trim the beginning of the path', function() {
       expect(paths.split('/foo/bar/baz')).to.eql(['foo', 'bar', 'baz']);

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -5,14 +5,15 @@
  * tested in "test/spec/lib/parser/rule.js".
  *
  */
+
 'use strict';
 
 const ruleset = require('../../../lib/ruleset');
 
-var invalidRulesets = {
+const invalidRulesets = {
   'are null': null,
   'are a string': 'wut',
-  'are missing': { noTopLevelRules: true },
+  'are missing': {noTopLevelRules: true},
   'include extra props': {
     rules: {
       '.read': true,
@@ -30,12 +31,12 @@ var invalidRulesets = {
   },
   'include null nodes': {
     rules: {
-      'foo': null
+      foo: null
     }
   },
   'include primitive nodes': {
     rules: {
-      'foo': 'true'
+      foo: 'true'
     }
   },
   'include unknown props': {
@@ -61,7 +62,7 @@ var invalidRulesets = {
   },
   'set index to an array of number': {
     rules: {
-      '.indexOn': [1,2,3]
+      '.indexOn': [1, 2, 3]
     }
   },
   'include unknown variables': {
@@ -101,7 +102,7 @@ var invalidRulesets = {
   }
 };
 
-var validRulesets = {
+const validRulesets = {
   'sets an empty rules property': {rules: {}},
   'defines valid read/write/indexOn/validate rules': {
     rules: {

--- a/test/spec/lib/ruleset.js
+++ b/test/spec/lib/ruleset.js
@@ -184,7 +184,7 @@ describe('Ruleset', function() {
 
       expect(set.root.a.$wildchild.$validate.toString()).to.equal('true');
       expect(set.root.a.$wildchild.$name).to.equal('$b');
-      expect(set.root.a.$wildchild.$isWildchild).to.be.true;
+      expect(set.root.a.$wildchild.$isWildchild).to.be.true();
     });
 
   });

--- a/test/spec/lib/store.js
+++ b/test/spec/lib/store.js
@@ -110,7 +110,7 @@ describe('store', function() {
           }
         }
       });
-      expect(data.a.$priority()).to.be.undefined;
+      expect(data.a.$priority()).to.be.undefined();
       expect(data.b.c.d.$priority()).to.equal(priority);
     });
 
@@ -144,8 +144,8 @@ describe('store', function() {
     });
 
     it('should return the node isPrimitive', function() {
-      expect(data.a.$isPrimitive()).to.be.true;
-      expect(data.b.$isPrimitive()).to.be.false;
+      expect(data.a.$isPrimitive()).to.be.true();
+      expect(data.b.$isPrimitive()).to.be.false();
     });
 
   });

--- a/test/spec/lib/store.js
+++ b/test/spec/lib/store.js
@@ -1,6 +1,7 @@
 /**
  * Test firebase data structure validation and navigation.
  */
+
 'use strict';
 
 const store = require('../../../lib/store');
@@ -48,7 +49,7 @@ describe('store', function() {
     expect(data.$value()).to.eql({b: {c: {d: 2}}});
   });
 
-  [true, 'two', 3, [1,2,3], null].forEach(function(v) {
+  [true, 'two', 3, [1, 2, 3], null].forEach(function(v) {
     let vType = typeof v;
 
     if (vType === 'object') {

--- a/test/spec/lib/util.js
+++ b/test/spec/lib/util.js
@@ -1,3 +1,4 @@
+
 'use strict';
 
 const util = require('../../../lib/util');

--- a/test/spec/plugins/chai.js
+++ b/test/spec/plugins/chai.js
@@ -1,10 +1,11 @@
 /**
  * Mocha test definition to test targaryen chai integration.
  */
+
 'use strict';
 
-var chai = require('chai'),
-  targaryen = require('../../../plugins/chai');
+const chai = require('chai');
+const targaryen = require('../../../plugins/chai');
 
 describe('Chai plugin', function() {
 
@@ -50,13 +51,13 @@ describe('Chai plugin', function() {
       targaryen.setFirebaseRules({
         rules: {
           users: {
-            '$user': {
+            $user: {
               '.read': 'auth.uid === $user',
               '.write': 'auth.isSuper === true'
             }
           },
           posts: {
-            '$post': {
+            $post: {
               '.read': true,
               '.write': true,
               '.validate': 'newData.hasChildren(["created", "text", "author"]) && newData.child("author").val() === auth.uid',
@@ -93,13 +94,13 @@ describe('Chai plugin', function() {
       targaryen.setFirebaseRules({
         rules: {
           users: {
-            '$user': {
+            $user: {
               '.read': 'auth.uid === $user',
               '.write': 'auth.isSuper === true'
             }
           },
           posts: {
-            '$post': {
+            $post: {
               '.read': true,
               '.write': true,
               '.validate': 'newData.hasChildren(["created", "text", "author"]) && newData.child("author").val() === auth.uid',
@@ -117,30 +118,30 @@ describe('Chai plugin', function() {
 
     it('permits read tests', function() {
       expect(null).cannot.read.path('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).can.read.path('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).can.read.path('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
     });
 
     it('permits write tests', function() {
 
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).cannot.write({smart: true})
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).cannot.write({smart: true})
       .to.path('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
 
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3', isSuper: true }).can.write({stupid: true})
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3', isSuper: true}).can.write({stupid: true})
       .to.path('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
 
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).cannot.write({
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).cannot.write({
         author: 'password:3403291b-fdc9-4995-9a54-9656241c835d',
         created: Date.now(),
         text: 'Hello!'
       })
       .to.path('posts/newpost');
 
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3' }).cannot.write({
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).cannot.write({
         author: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'
       })
       .to.path('posts/newpost');
 
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3' }).can.write({
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).can.write({
         author: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3',
         created: Date.now(),
         text: 'Hello!'
@@ -168,12 +169,12 @@ describe('Chai plugin', function() {
         }
       });
 
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3' }).can.patch({
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).can.patch({
         text: 'Hello World!'
       })
       .to.path('posts/somePost');
 
-      expect({ uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3' }).cannot.patch({
+      expect({uid: 'password:500f6e96-92c6-4f60-ad5d-207253aee4d3'}).cannot.patch({
         text: 'Hello World!',
         created: Date.now()
       })


### PR DESCRIPTION
Since the next branch modifies most of the source code, we might as well reformat it now and ensure consistent style in the future.

## The process:

- convert jshint config to eslint (and fix jshint config to some extend).
- format source code.
- test formatting in CI.
- add command to fix formatting issue.
- add command to report formatting issues with html reporter.
- add contributing notes.

## XO overrides:

- set source mode to script instead of module.
- indent with space.
- allow non strict comparison to null.
- allow use before define for constructors.
- allow one line brace style.
- one var for uninitialised vars.
- no space before function paren.

## XO Extensions:

- Only use features supported by node +4.3.
- no var (use const or let).
- no confusing arrow function body.
- use bracket for arrow function body as needed.
- new line after variables declaration.
- one line around ‘use strict’.
- require object shorthand.
- prefer arrow callback.
- prefer const.
