### PR TITLE
Stricter comparison type inferring

### DIFF
--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -12,22 +12,22 @@ const rootTypes = {
 
 };
 
-const binaryArithmeticOperatorTypes = {
-  '-': true,
-  '*': true,
-  '/': true,
-  '%': true
-};
-
-const binaryComparisonOperatorTypes = {
-  '==': true,
-  '!=': true,
-  '===': true,
-  '!==': true,
-  '>': true,
-  '>=': true,
-  '<': true,
-  '<=': true
+const arithmeticTypes = new Set(['number']);
+const comparableTypes = new Set(['string', 'number']);
+const equalityTypes = new Set(['string', 'number', 'boolean', 'null']);
+const binaryOperatorTypes = {
+  '-': {validTypes: arithmeticTypes, inferTo: 'number'},
+  '*': {validTypes: arithmeticTypes, inferTo: 'number'},
+  '/': {validTypes: arithmeticTypes, inferTo: 'number'},
+  '%': {validTypes: arithmeticTypes, inferTo: 'number'},
+  '==': {validTypes: equalityTypes, inferTo: 'boolean'},
+  '!=': {validTypes: equalityTypes, inferTo: 'boolean'},
+  '===': {validTypes: equalityTypes, inferTo: 'boolean'},
+  '!==': {validTypes: equalityTypes, inferTo: 'boolean'},
+  '>': {validTypes: comparableTypes, inferTo: 'boolean'},
+  '>=': {validTypes: comparableTypes, inferTo: 'boolean'},
+  '<': {validTypes: comparableTypes, inferTo: 'boolean'},
+  '<=': {validTypes: comparableTypes, inferTo: 'boolean'}
 };
 
 const unaryOperatorTypes = {
@@ -99,7 +99,7 @@ const properties = {
 
 };
 
-const primitiveTypes = new Set(['string', 'number', 'boolean', 'primitive']);
+const primitiveTypes = new Set(['string', 'number', 'boolean', 'null', 'primitive']);
 
 function isPrimitiveType(type) {
   return primitiveTypes.has(type);
@@ -236,6 +236,11 @@ Scope.prototype._inferLiteral = function(node) {
     throw nodeError(node, 'undefined is not valid in rules');
   }
 
+  if (node.value === null) {
+    node.inferredType = 'null';
+    return;
+  }
+
   node.inferredType = typeof node.value;
 
 };
@@ -278,26 +283,20 @@ Scope.prototype._inferBinaryExpression = function(node) {
 
   }
 
-  if (binaryArithmeticOperatorTypes[node.operator]) {
+  if (binaryOperatorTypes[node.operator]) {
 
-    const validTypes = new Set(['any', 'primitive', 'number']);
+    const validTypes = binaryOperatorTypes[node.operator].validTypes;
+    const inferredType = binaryOperatorTypes[node.operator].inferTo;
 
-    if (!validTypes.has(left)) {
-      throw nodeError(node, `Invalid ${node.operator} expression: left operand is not a number.`);
+    if (!validTypes.has(left) && !fuzzyType(left)) {
+      throw nodeError(node, `Invalid ${node.operator} expression: left operand should be ${Array.from(validTypes).join(', ')}.`);
     }
 
-    if (!validTypes.has(right)) {
-      throw nodeError(node, `Invalid ${node.operator} expression: right operand is not a number.`);
+    if (!validTypes.has(right) && !fuzzyType(right)) {
+      throw nodeError(node, `Invalid ${node.operator} expression: right operand operand should be ${Array.from(validTypes).join(', ')}.`);
     }
 
-    node.inferredType = 'number';
-    return;
-
-  }
-
-  if (binaryComparisonOperatorTypes[node.operator]) {
-
-    node.inferredType = 'boolean';
+    node.inferredType = inferredType;
     return;
 
   }

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -47,7 +47,12 @@ const invalidRules = [
   'root.hasChildren(["foo", 7])', // hasChildren only takes strings
   'root.child("str").val().matches("/foo/")', // matches only takes a regular expression literal
   'auth.foo.notFound() == false', // auth properties can only be an object or a primitives
-  'root.val().notFound == false' // val only returns primitives.
+  'root.val().notFound == false', // val only returns primitives.
+  'root.child("foo") != null', // child returned value is not a primitive.
+  'root.val() > true', // comparaison to  number and string only.
+  'root.val() < true',
+  'root.val() >= true',
+  'root.val() <= true'
 ];
 
 const ruleEvaluationTests = [{


### PR DESCRIPTION
- add null inferred type for literal types.
- merge arithmetic and comparison operation type inferring.
- test types of left and right side of operation.

Fix #85 and #84 