### PR TITLE
Fix null handling

### DIFF
--- a/lib/parser/rule.js
+++ b/lib/parser/rule.js
@@ -130,12 +130,54 @@ RuleEvaluator.prototype._evalLogicalExpression = function(node) {
 
 };
 
+const additionTypes = new Set(['number', 'string']);
+
 RuleEvaluator.prototype._evalBinaryExpression = function(node) {
 
   var left = this.evaluate(node.left),
     right = this.evaluate(node.right);
 
-  switch(node.operator) {
+  switch (node.operator) {
+  case '-':
+  case '/':
+  case '*':
+  case '%':
+    if (typeof left !== 'number') {
+      throw new nodeError(node, `${node.left} should evaluate to a number.`);
+    }
+
+    if (typeof right !== 'number') {
+      throw new nodeError(node, `${node.right} should evaluate to a number.`);
+    }
+
+    break;
+
+  case '+':
+    if (!additionTypes.has(typeof left)) {
+      throw new nodeError(node, `${node.left} should evaluate to a ${Array.from(additionTypes).join(' or ')}.`);
+    }
+
+    if (!additionTypes.has(typeof right)) {
+      throw new nodeError(node, `${node.right} should evaluate to a ${Array.from(additionTypes).join(' or ')}.`);
+    }
+
+    break;
+
+  case '>':
+  case '>=':
+  case '<':
+  case '<=':
+    if ((typeof left) !== (typeof right)) {
+      throw new nodeError(node, `${node.right} and ${node.left} should evaluate to values of the same type.`);
+    }
+
+    break;
+
+  default:
+    break;
+  }
+
+  switch (node.operator) {
   case '+':
     return left + right;
   case '-':
@@ -167,12 +209,17 @@ RuleEvaluator.prototype._evalBinaryExpression = function(node) {
 };
 
 RuleEvaluator.prototype._evalUnaryExpression = function(node) {
+  const value = this.evaluate(node.argument);
 
   switch (node.operator) {
   case '!':
-    return !this.evaluate(node.argument);
+    return !value;
   case '-':
-    return -this.evaluate(node.argument);
+    if (typeof value !== 'number') {
+      throw nodeError(node, `${nodeError.argument} should evaluate to a number`);
+    }
+
+    return -value;
   default:
     throw nodeError(node, 'unknown unary operator ' + node.operator);
   }

--- a/lib/parser/string-methods.js
+++ b/lib/parser/string-methods.js
@@ -5,19 +5,39 @@ var replaceall = require('replaceall');
 
 module.exports = {
 
-  contains: function(str, substr) {
+  contains(str, substr) {
+    if (typeof substr !== 'string') {
+      throw new Error(`${substr} is not a string.`);
+    }
+
     return str.indexOf(substr) !== -1;
   },
-  beginsWith: function(str, substr) {
+
+  beginsWith(str, substr) {
+    if (typeof substr !== 'string') {
+      throw new Error(`${substr} is not a string.`);
+    }
+
     return str.indexOf(substr) === 0;
   },
-  endsWith: function(str, substr) {
+
+  endsWith(str, substr) {
+    if (typeof substr !== 'string') {
+      throw new Error(`${substr} is not a string.`);
+    }
+
     return str.indexOf(substr) + substr.length === str.length;
   },
-  replace: function(str, substr, replacement) {
+
+  replace(str, substr, replacement) {
+    if (typeof substr !== 'string' || typeof replacement !== 'string') {
+      throw new Error(`${substr} is not a string.`);
+    }
+
     return replaceall(substr, replacement, str);
   },
-  matches: function(str, regex) {
+
+  matches(str, regex) {
     return regex.test(str);
   }
 

--- a/lib/rule-data-snapshot.js
+++ b/lib/rule-data-snapshot.js
@@ -272,6 +272,11 @@ RuleDataSnapshot.prototype.exists = function() {
 
 RuleDataSnapshot.prototype.child = function(childPath) {
   var newPath;
+
+  if (typeof childPath !== 'string') {
+    throw new Error(`${childPath} should be a string.`);
+  }
+
   if (this._path) {
     newPath = [this._path, childPath].join('/');
   } else {
@@ -294,6 +299,10 @@ RuleDataSnapshot.prototype.parent = function() {
 
 
 RuleDataSnapshot.prototype.hasChild = function(name) {
+  if (typeof name !== 'string') {
+    throw new Error(`${name} should be a string.`);
+  }
+
   return this.child(name).exists();
 };
 
@@ -308,14 +317,15 @@ RuleDataSnapshot.prototype.hasChildren = function(names) {
     return Object.keys(this._getVal()).filter(function(key) {
       return key.charAt(0) !== '.';
     }).length > 0;
-
-  } else {
-
-    return names.every(function(name) {
-      return this.child(name).exists();
-    }, this);
-
   }
+
+  if (names.some(n => typeof n !== 'string')) {
+    throw new Error(`${names} should be an array of string.`);
+  }
+
+  return names.every(function(name) {
+    return this.child(name).exists();
+  }, this);
 
 };
 

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -127,6 +127,51 @@ var ruleEvaluationTests = [{
   wildchildren: [],
   scope: {auth: {foo: {baz: true}}},
   result: true
+}, {
+  rule: 'auth.foo.baz == null',
+  wildchildren: [],
+  scope: {auth: {}},
+  result: true
+}, {
+  rule: 'root.child("foo").child(auth.foo).val() != null',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
+}, {
+  rule: 'root.child("foo").child(auth.foo).val() == null',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
+}, {
+  rule: 'root.child("foo").child(auth.foo).exists()',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
+}, {
+  rule: 'root.child("foo").child(auth.foo).exists() == false',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
+}, {
+  rule: 'root.child("foo").hasChild(auth.foo)',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
+}, {
+  rule: 'root.child("foo").hasChild(auth.foo) == false',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
+}, {
+  rule: 'root.child("foo").hasChildren([auth.foo])',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
+}, {
+  rule: 'root.child("foo").hasChildren([auth.foo]) == false',
+  wildchildren: [],
+  scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
+  willThrow: true
 }];
 
 describe('Rule', function() {

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -172,6 +172,51 @@ var ruleEvaluationTests = [{
   wildchildren: [],
   scope: {auth: null, root: new RuleDataSnapshot({foo: {bar: {'.value': true}}})},
   willThrow: true
+}, {
+  rule: '"foo".contains(auth.foo)',
+  wildchildren: [],
+  scope: {auth: null},
+  willThrow: true
+}, {
+  rule: '"foo1".contains(auth.foo)',
+  wildchildren: [],
+  scope: {auth: {foo: 1}},
+  willThrow: true
+}, {
+  rule: '"foo".beginsWith(auth.foo)',
+  wildchildren: [],
+  scope: {auth: null},
+  willThrow: true
+}, {
+  rule: '"1foo".beginsWith(auth.foo)',
+  wildchildren: [],
+  scope: {auth: {foo: 1}},
+  willThrow: true
+}, {
+  rule: '"foo".endsWith(auth.foo)',
+  wildchildren: [],
+  scope: {auth: null},
+  willThrow: true
+}, {
+  rule: '"foo1".endsWith(auth.foo)',
+  wildchildren: [],
+  scope: {auth: {foo: 1}},
+  willThrow: true
+}, {
+  rule: '"foo".replace(auth.foo, "bar") == "foo"',
+  wildchildren: [],
+  scope: {auth: null},
+  willThrow: true
+}, {
+  rule: '"foo1".replace(auth.foo, "bar") == "foobar"',
+  wildchildren: [],
+  scope: {auth: {foo: 1}},
+  willThrow: true
+}, {
+  rule: '"foobar".replace("bar", auth.foo) == "foo1"',
+  wildchildren: [],
+  scope: {auth: {foo: 1}},
+  willThrow: true
 }];
 
 describe('Rule', function() {
@@ -215,7 +260,7 @@ describe('Rule', function() {
           expect(function() {
             var rule = new Rule(ruleTest.rule, ruleTest.wildchildren);
             rule.evaluate(ruleTest.scope, ruleTest.skipOnNoValue);
-          }).to.throw();
+          }, ruleTest.rule).to.throw();
 
         } else {
 

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -217,6 +217,26 @@ var ruleEvaluationTests = [{
   wildchildren: [],
   scope: {auth: {foo: 1}},
   willThrow: true
+}, {
+  rule: '-auth.foo == -1',
+  wildchildren: [],
+  scope: {auth: null},
+  willThrow: true
+}, {
+  rule: '-auth.foo == -1',
+  wildchildren: [],
+  scope: {auth: {foo: 'one'}},
+  willThrow: true
+}, {
+  rule: '!(auth.foo == null)',
+  wildchildren: [],
+  scope: {auth: null},
+  result: false
+}, {
+  rule: '!(auth.foo == null)',
+  wildchildren: [],
+  scope: {auth: {foo: 'one'}},
+  result: true
 }];
 
 describe('Rule', function() {
@@ -270,6 +290,149 @@ describe('Rule', function() {
 
         }
 
+      });
+
+    });
+
+    describe('with arithmetic operator', function() {
+      const expectWith = (rule, auth) => expect(() => new Rule(rule, []).evaluate({auth}), rule);
+
+      ['+', '-', '*', '%'].forEach(function(op) {
+        const r1 = `(auth.foo ${op} 1) == 1`;
+        const r2 = `(auth.foo ${op} 1) != 1`;
+        const r3 = `(1 ${op} auth.foo) == 1`;
+        const r4 = `(1 ${op} auth.foo) != 1`;
+
+        describe(op, function() {
+
+          it('should throw on null values', function() {
+            const auth = null;
+
+            [r1, r2, r3, r4].forEach(r => expectWith(r, auth).to.throw());
+          });
+
+          it('should throw on boolean values', function() {
+            const auth = {foo: true};
+
+            [r1, r2, r3, r4].forEach(r => expectWith(r, auth).to.throw());
+          });
+
+          it.skip('should not throw on number values', function() {
+            const auth = {foo: 1};
+
+            [r1, r2, r3, r4].forEach(r => expectWith(r, auth).to.not.throw());
+          });
+
+          if (op === '+') {
+
+            it('should not throw on string values', function() {
+              const auth = {foo: 'one'};
+
+              [r1, r2, r3, r4].forEach(r => expectWith(r, auth).to.not.throw());
+            });
+
+          } else {
+
+            it('should throw on string values', function() {
+              const auth = {foo: 'one'};
+
+              [r1, r2, r3, r4].forEach(r => expectWith(r, auth).to.throw());
+            });
+
+          }
+
+        });
+
+      });
+
+    });
+
+    describe('with equality operators', function() {
+
+      it('should not throw on null value', function() {
+        ['==', '===', '!=', '!=='].forEach(function(op) {
+          const r1 = `'foo' ${op} auth.foo`;
+          const r2 = `auth.foo ${op} 'foo'`;
+          const auth = null;
+
+          [r1, r2].forEach(r => expect(() => new Rule(r, []).evaluate({auth}), r).to.not.throw());
+        });
+      });
+
+    });
+
+    describe('with equality operators', function() {
+
+      it('should not throw on null value', function() {
+        ['==', '===', '!=', '!=='].forEach(function(op) {
+          const r1 = `'foo' ${op} auth.foo`;
+          const r2 = `auth.foo ${op} 'foo'`;
+          const auth = null;
+
+          [r1, r2].forEach(r => expect(() => new Rule(r, []).evaluate({auth}), r).to.not.throw());
+        });
+      });
+
+      it('should not throw on different value type tests', function() {
+        ['==', '===', '!=', '!=='].forEach(function(op) {
+          const r1 = `'one' ${op} auth.foo`;
+          const r2 = `auth.foo ${op} 'one'`;
+          const auth = {foo: 1};
+
+          [r1, r2].forEach(r => expect(() => new Rule(r, []).evaluate({auth}), r).to.not.throw());
+        });
+      });
+
+    });
+
+    describe('with comparison operators', function() {
+
+      it('should not throw on null value', function() {
+        ['>', '>=', '<', '<='].forEach(function(op) {
+          const r1 = `auth.bar ${op} auth.foo`;
+          const r2 = `auth.foo ${op} auth.bar`;
+          const auth = null;
+
+          [r1, r2].forEach(r => expect(() => new Rule(r, []).evaluate({auth}), r).to.not.throw());
+        });
+      });
+
+      it('should throw on different value type tests', function() {
+        ['>', '>=', '<', '<='].forEach(function(op) {
+          const r1 = `'one' ${op} auth.foo`;
+          const r2 = `auth.foo ${op} 'one'`;
+          const auth = {foo: 1};
+
+          [r1, r2].forEach(r => expect(() => new Rule(r, []).evaluate({auth}), r).to.throw());
+        });
+      });
+
+    });
+
+    describe('with logical expression', function() {
+
+      it('should evaluate each branch lazily', function() {
+        const fail = new Rule('auth.foo > 1 || true', []);
+        const pass = new Rule('true || auth.foo > 1', []);
+        const scope = {auth: null};
+
+        expect(() => fail.evaluate(scope)).to.throw();
+        expect(() => pass.evaluate(scope)).to.not.throw();
+        expect(pass.evaluate(scope)).to.be.true;
+      });
+
+    });
+
+    describe('with logical expression', function() {
+
+      it('should evaluate each branch lazily', function() {
+        const fail = new Rule('true ? auth.foo > 1 : true', []);
+        const pass = new Rule('true ? true : auth.foo > 1', []);
+        const scope = {auth: null};
+
+        expect(() => fail.evaluate(scope)).to.throw();
+        expect(() => pass.evaluate(scope)).to.not.throw();
+        expect(pass.evaluate(scope)).to.be.true;
       });
 
     });


### PR DESCRIPTION
- snapshot methods `child`, `hasChild` and `hasChildren` throw when receiving non string path arguments.
- string methods throw when receiving non strong substring arguments.
- arithmetic and comparison operations check type at runtime.

Fix #86 