### PR TITLE
Enable all tests

### DIFF
--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -162,7 +162,7 @@ describe('the targaryen Jasmine plugin', function() {
     });
   });
 
-  xdescribe('using nested variables in path', function() {
+  describe('using nested variables in path', function() {
 
     beforeEach(function() {
       // using double quotes to make the data & rules compatible with Firebase (web interface)
@@ -304,8 +304,6 @@ describe('the targaryen Jasmine plugin', function() {
           "bool": null,
           "number": null
       });
-
-      pending("This doesn't work in the tests, but this works at least in the Javascrip SDK");
     });
 
     it('should not be able to write invalid data by deleting a sibling', function() {


### PR DESCRIPTION
- Enable the skip test related to #36
   @matijse PR from @mhuebert in v2.2.1 and v2.3.0 to cleanup null node has fixed the skipped tests.
- Enable tests related to nested wildchildren
   @petrusek It fixed since 2.2.0 I think.