### PR TITLE
Fix snapshot parent

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -251,7 +251,7 @@ class RuleDataSnapshot {
    */
   parent() {
     if (!this[pathKey]) {
-      return null;
+      throw new Error('This node if the database root and has no parent.');
     }
 
     const path = this[pathKey].split('/').slice(0, -1).join('/');

--- a/test/spec/lib/database.js
+++ b/test/spec/lib/database.js
@@ -133,7 +133,7 @@ describe('database', function() {
         expect(snap.parent().val()).to.deep.equal({foo});
       });
 
-      it.skip('fail if the snapshot was refering to the data root ', function() {
+      it('fail if the snapshot was refering to the data root ', function() {
         const data = null;
         const snap = database.create(rules, data).snapshot('/');
 

--- a/test/spec/lib/parser/fixtures.json
+++ b/test/spec/lib/parser/fixtures.json
@@ -1056,6 +1056,12 @@
       "isValid": true,
       "failAtRuntime": false,
       "evaluateTo": true
+    },
+    {
+      "rule": "root.parent().exists()",
+      "user": "unauth",
+      "isValid": true,
+      "failAtRuntime": true
     }
   ]
 }


### PR DESCRIPTION
Should throw if node is the database root.