### PR TITLE
Describe operation in result info

### DIFF
--- a/lib/database/results.js
+++ b/lib/database/results.js
@@ -50,7 +50,49 @@ class Result {
   }
 
   get info() {
-    const logs = this.logs.map(r => {
+    const info = [
+      this.description,
+      this.evaluations
+    ];
+
+    if (this.allowed) {
+      info.push(`${this.type} was allowed.`);
+
+      return info.join('\n');
+    }
+
+    if (!this.permitted) {
+      info.push(`No .${this.permissionType} rule allowed the operation.`);
+    }
+
+    if (!this.validated) {
+      info.push('One or more .validate rules disallowed the operation.');
+    }
+
+    info.push(`${this.type} was denied.`);
+
+    return info.join('\n');
+  }
+
+  get description() {
+    const op = `Attempt to ${this.type} ${this.path} as ${JSON.stringify(this.auth)}.\n`;
+
+    switch (this.type) {
+
+    case 'write':
+      return `${op}New Value: "${JSON.stringify(this.newValue, undefined, 2)}".\n`;
+
+    case 'patch':
+      return `${op}Patch: "${JSON.stringify(this.newValue, undefined, 2)}".\n`;
+
+    default:
+      return op;
+
+    }
+  }
+
+  get evaluations() {
+    return this.logs.map(r => {
       if (r.hasNoRules === true) {
         return `/${r.path}: ${this.permissionType} <no rules>\n`;
       }
@@ -63,25 +105,7 @@ class Result {
       }
 
       return `${header}  => ${result}\n${pad.lines(r.detailed)}\n`;
-    });
-
-    if (this.allowed) {
-      logs.push(`${this.type} was allowed.`);
-
-      return logs.join('\n');
-    }
-
-    if (!this.permitted) {
-      logs.push(`No .${this.permissionType} rule allowed the operation.`);
-    }
-
-    if (!this.validated) {
-      logs.push('One or more .validate rules disallowed the operation.');
-    }
-
-    logs.push(`${this.type} was denied.`);
-
-    return logs.join('\n');
+    }).join('\n');
   }
 
   get root() {

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,7 +11,7 @@ let debug = true;
 let verbose = true;
 let data, rules, db;
 
-const users = exports.users = {
+exports.users = {
 
   unauthenticated: null,
   facebook: {
@@ -47,46 +47,15 @@ const users = exports.users = {
 
 };
 
-function getUserDescription(auth) {
-
-  if (auth == null) {
-    return 'an unauthenticated user';
-  }
-
-  if (auth.$description) {
-    return auth.$description;
-  }
-
-  switch (auth) {
-  case users.facebook:
-    return 'a user authenticated via Facebook';
-  case users.twitter:
-    return 'a user authenticated via Twitter';
-  case users.anonymous:
-    return 'a user authenticated anonymously';
-  case users.github:
-    return 'a user authenticated via Github';
-  case users.google:
-    return 'a user authenticated via Google';
-  case users.password:
-    return 'a user authenticated via Password Login';
-  default:
-    return 'a user with credentials ' + JSON.stringify(auth);
-  }
-
-}
-
 function debugInfo(msg, result, padding) {
-  const info = debug === true ? `${msg}\n${result.info}` : msg;
+  const info = debug === true ? `${msg}\n\n${result.info}` : msg;
 
   return padding == null ? info : pad.lines(info, {length: padding});
 }
 
 exports.readableError = function(result, padding) {
 
-  const msg = 'Expected ' + getUserDescription(result.auth) +
-    ' not to be able to read ' + result.path +
-    ', but the rules allowed the read.';
+  const msg = 'Expected the read operation to fail.';
 
   return debugInfo(msg, result, padding);
 
@@ -94,9 +63,7 @@ exports.readableError = function(result, padding) {
 
 exports.unreadableError = function(result, padding) {
 
-  const msg = 'Expected ' + getUserDescription(result.auth) +
-    ' to be able to read ' + result.path +
-    ', but the rules denied the read.';
+  const msg = 'Expected the read operation to succeed.';
 
   return debugInfo(msg, result, padding);
 
@@ -104,10 +71,7 @@ exports.unreadableError = function(result, padding) {
 
 exports.writableError = function(result, padding) {
 
-  const msg = 'Expected ' + getUserDescription(result.auth) +
-    ' not to be able to write `' + JSON.stringify(result.newValue) + '`' +
-    ' to ' + result.path +
-    ', but the rules allowed the write.';
+  const msg = 'Expected the write operation to fail.';
 
   return debugInfo(msg, result, padding);
 
@@ -115,10 +79,7 @@ exports.writableError = function(result, padding) {
 
 exports.unwritableError = function(result, padding) {
 
-  const msg = 'Expected ' + getUserDescription(result.auth) +
-    ' to be able to write `' + JSON.stringify(result.newValue) + '`' +
-    ' to ' + result.path +
-    ', but the rules denied the write.';
+  const msg = 'Expected the write operation to succeed.';
 
   return debugInfo(msg, result, padding);
 

--- a/test/spec/lib/database/index.js
+++ b/test/spec/lib/database/index.js
@@ -1108,8 +1108,6 @@ describe('database', function() {
 
       const result = db.update('/', patch);
 
-      console.log(result.info);
-
       expect(result.info).to.contain('/bar: write <no rules>');
 
     });

--- a/test/spec/lib/util.js
+++ b/test/spec/lib/util.js
@@ -42,57 +42,6 @@ describe('util', function() {
 
   });
 
-  describe('user description', function() {
-    const path = '/';
-    let result, data;
-
-    beforeEach(function() {
-      util.setFirebaseRules({rules: {}});
-      util.setFirebaseData(null);
-      data = util.getFirebaseData();
-    });
-
-    it('should describe unauthenticated users', function() {
-      result = database.results.read(path, data);
-      expect(util.readableError(result)).to.contain('unauthenticated user');
-    });
-
-    it('should describe anonymous users', function() {
-      result = database.results.read(path, data.as(util.users.anonymous));
-      expect(util.readableError(result)).to.contain('user authenticated anonymously');
-    });
-
-    it('should describe password users', function() {
-      result = database.results.read(path, data.as(util.users.password));
-      expect(util.readableError(result)).to.contain('user authenticated via Password Login');
-    });
-
-    it('should describe auth', function() {
-      const auth = {uid: 123};
-
-      result = database.results.read(path, data.as(auth));
-      expect(util.readableError(result)).to.contain(JSON.stringify(auth));
-    });
-
-    it('should describe auth with $description', function() {
-      const $description = 'some description';
-
-      result = database.results.read(path, data.as({$description}));
-      expect(util.readableError(result)).to.contain($description);
-    });
-
-    ['Facebook', 'Twitter', 'Github', 'Google'].forEach(function(provider) {
-      const auth = util.users[provider.toLowerCase()];
-
-      it('should describe Facebook users', function() {
-        result = database.results.read(path, data.as(auth));
-        expect(util.readableError(result)).to.contain(`user authenticated via ${provider}`);
-      });
-
-    });
-
-  });
-
   ['readableError', 'unreadableError'].forEach(function(name) {
     const helper = util[name];
 
@@ -105,14 +54,6 @@ describe('util', function() {
         util.setFirebaseRules({rules: {}});
         util.setFirebaseData(null);
         result = database.results.read(path, util.getFirebaseData().as({$description}));
-      });
-
-      it('should include the path', function() {
-        expect(helper(result)).to.contain(path);
-      });
-
-      it('should include the user', function() {
-        expect(helper(result)).to.contain($description);
       });
 
       it('should include result info if debug is enabled', function() {
@@ -145,18 +86,6 @@ describe('util', function() {
         const data = util.getFirebaseData().as({$description});
 
         result = database.results.write(path, data, data, value);
-      });
-
-      it('should include the path', function() {
-        expect(helper(result)).to.contain(path);
-      });
-
-      it('should include the user', function() {
-        expect(helper(result)).to.contain($description);
-      });
-
-      it('should include the value', function() {
-        expect(helper(result)).to.contain(value);
       });
 
       it('should include result info if debug is enabled', function() {


### PR DESCRIPTION
Some of those info were shown by `targaryen.utils.*Errors` helpers. By having them in `Result.info`, libraries building on top of `Database` directly won’t need to duplicate the `targaryen.utils` routines.