### PR TITLE
feat: add json parsing helpers to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ Targaryen provides three convenient ways to run tests:
 - as a set of custom matchers for [Jasmine](https://jasmine.github.io):
 
     ```js
-    const targaryen = require('targaryen/plugins/jasmine');;
+    const targaryen = require('targaryen/plugins/jasmine');
+    const rules = targaryen.json.loadSync(RULES_PATH);
 
     describe('my security rules', function() {
 
       beforeEach(function() {
         jasmine.addMatchers(targaryen.matchers);
         targaryen.setFirebaseData(require(DATA_PATH));
-        targaryen.setFirebaseRules(require(RULES_PATH));
+        targaryen.setFirebaseRules(rules);
       });
 
       it('should allow authenticated user to read all data', function() {
@@ -70,6 +71,7 @@ Targaryen provides three convenient ways to run tests:
     const chai = require('chai');
     const targaryen = require('targaryen/plugins/chai');
     const expect = chai.expect;
+    const rules = targaryen.json.loadSync(RULES_PATH);
 
     chai.use(targaryen);
 
@@ -77,7 +79,7 @@ Targaryen provides three convenient ways to run tests:
 
       before(function() {
         targaryen.setFirebaseData(require(DATA_PATH)));
-        targaryen.setFirebaseRules(require(RULES_PATH));
+        targaryen.setFirebaseRules(rules);
       });
 
       it('should allow authenticated user to read all data', function() {

--- a/docs/chai/examples/erroring.js
+++ b/docs/chai/examples/erroring.js
@@ -3,8 +3,8 @@
 // in your app this would be require('targaryen/plugins/chai')
 const targaryen = require('../../../plugins/chai');
 const chai = require('chai');
-const expect = chai.expect;
-const users = targaryen.users;
+const path = require('path');
+const rules = targaryen.json.loadSync(path.join(__dirname, 'bad-rules.json'));
 
 chai.use(targaryen);
 
@@ -12,7 +12,7 @@ describe('An invalid set of security rules', function() {
 
   it('causes Targaryen to throw', function() {
     targaryen.setFirebaseData(require('./data.json'));
-    targaryen.setFirebaseRules(require('./bad-rules.json'));
+    targaryen.setFirebaseRules(rules);
   });
 
 });

--- a/docs/chai/examples/failing.js
+++ b/docs/chai/examples/failing.js
@@ -5,6 +5,8 @@ const targaryen = require('../../../plugins/chai');
 const chai = require('chai');
 const expect = chai.expect;
 const users = targaryen.users;
+const path = require('path');
+const rules = targaryen.json.loadSync(path.join(__dirname, 'rules.json'));
 
 chai.use(targaryen);
 
@@ -12,7 +14,7 @@ describe('A valid set of security rules and data', function() {
 
   before(function() {
     targaryen.setFirebaseData(require('./data.json'));
-    targaryen.setFirebaseRules(require('./rules.json'));
+    targaryen.setFirebaseRules(rules);
   });
 
   it('can have read errors', function() {

--- a/docs/chai/examples/passing.js
+++ b/docs/chai/examples/passing.js
@@ -5,6 +5,8 @@ const targaryen = require('../../../plugins/chai');
 const chai = require('chai');
 const expect = chai.expect;
 const users = targaryen.users;
+const path = require('path');
+const rules = targaryen.json.loadSync(path.join(__dirname, 'rules.json'));
 
 chai.use(targaryen);
 
@@ -12,7 +14,7 @@ describe('A valid set of security rules and data', function() {
 
   before(function() {
     targaryen.setFirebaseData(require('./data.json'));
-    targaryen.setFirebaseRules(require('./rules.json'));
+    targaryen.setFirebaseRules(rules);
   });
 
   it('can be tested against', function() {

--- a/docs/jasmine/examples/spec/security/erroring.js
+++ b/docs/jasmine/examples/spec/security/erroring.js
@@ -2,6 +2,9 @@
 
 // in your app this would be require('targaryen/plugins/jasmine')
 const targaryen = require('../../../../../plugins/jasmine');
+const path = require('path');
+
+const rules = targaryen.json.loadSync(path.join(__dirname, 'bad-rules.json'));
 
 describe('An invalid set of security rules and data', function() {
 
@@ -12,7 +15,7 @@ describe('An invalid set of security rules and data', function() {
   it('causes Targaryen to throw', function() {
 
     targaryen.setFirebaseData(require('./data.json'));
-    targaryen.setFirebaseRules(require('./bad-rules.json'));
+    targaryen.setFirebaseRules(rules);
 
   });
 

--- a/docs/jasmine/examples/spec/security/failing.js
+++ b/docs/jasmine/examples/spec/security/failing.js
@@ -2,10 +2,13 @@
 
 // in your app this would be require('targaryen/plugins/jasmine')
 const targaryen = require('../../../../../plugins/jasmine');
+const path = require('path');
+
+const rules = targaryen.json.loadSync(path.join(__dirname, 'rules.json'));
 const users = targaryen.users;
 
 targaryen.setFirebaseData(require('./data.json'));
-targaryen.setFirebaseRules(require('./rules.json'));
+targaryen.setFirebaseRules(rules);
 
 describe('A valid set of security rules and data', function() {
 

--- a/docs/jasmine/examples/spec/security/passing.js
+++ b/docs/jasmine/examples/spec/security/passing.js
@@ -3,15 +3,18 @@
 
 // in your app this would be require('targaryen/plugins/jasmine')
 const targaryen = require('../../../../../plugins/jasmine');
+const path = require('path');
+
+const rules = targaryen.json.loadSync(path.join(__dirname, 'rules.json'));
 const users = targaryen.users;
 
 targaryen.setFirebaseData(require('./data.json'));
-targaryen.setFirebaseRules(require('./rules.json'));
+targaryen.setFirebaseRules(rules);
 
 describe('A valid set of security rules and data', function() {
 
   beforeEach(function() {
-    jasmine.addMatchers(targaryen.jasmine.matchers);
+    jasmine.addMatchers(targaryen.matchers);
   });
 
   it('can be tested against', function() {

--- a/docs/jasmine/examples/spec/support/jasmine.json
+++ b/docs/jasmine/examples/spec/support/jasmine.json
@@ -1,9 +1,6 @@
 {
-  "spec_dir": "..",
+  "spec_dir": "spec/security",
   "spec_files": [
     "**/*.js"
-  ],
-  "helpers": [
-    "helpers/**/*.js"
   ]
 }

--- a/plugins/chai.js
+++ b/plugins/chai.js
@@ -104,6 +104,7 @@ function chaiTargaryen(chai, utils) {
 
 }
 
+chaiTargaryen.json = require('firebase-json');
 chaiTargaryen.users = targaryen.util.users;
 chaiTargaryen.setDebug = targaryen.util.setDebug;
 chaiTargaryen.setVerbose = targaryen.util.setVerbose;

--- a/plugins/jasmine.js
+++ b/plugins/jasmine.js
@@ -13,6 +13,7 @@ exports.setFirebaseRules = targaryen.util.setFirebaseRules;
 exports.setDebug = targaryen.util.setDebug;
 exports.setVerbose = targaryen.util.setVerbose;
 exports.users = targaryen.util.users;
+exports.json = require('firebase-json');
 
 exports.matchers = {
 


### PR DESCRIPTION
Add firebase-json to chai and jasmine reference implement ion and update documentation showing how to use `json.loadSync(path)`.

fix #30 