### PR TITLE
Properly handle computed member expressions

### DIFF
--- a/lib/parser/statement/member.js
+++ b/lib/parser/statement/member.js
@@ -93,16 +93,16 @@ class MemberNode extends Node {
 
     if (this.computed) {
       this.property = Node.from(source, astNode.property, scope);
-    }
-
-    try {
-      this.property = Node.from(
-        source,
-        astNode.property,
-        objectType === 'any' ? scopeFactory.any() : scopeFactory.create(MemberNode.properties[objectType])
-      );
-    } catch (e) {
-      throw new ParseError(this, msg);
+    } else {
+      try {
+        this.property = Node.from(
+          source,
+          astNode.property,
+          objectType === 'any' ? scopeFactory.any() : scopeFactory.create(MemberNode.properties[objectType])
+        );
+      } catch (e) {
+        throw new ParseError(this, msg);
+      }
     }
   }
 

--- a/test/spec/lib/parser/fixtures.json
+++ b/test/spec/lib/parser/fixtures.json
@@ -14,6 +14,13 @@
   },
   "tests": [
     {
+      "rule": "auth.foo['b' + 'ar'] == true",
+      "user": "bob",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
       "rule": "1 < 2",
       "user": "unauth",
       "isValid": true,

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -70,6 +70,16 @@ describe('Rule', function() {
 
     });
 
+    it('properly handles computed member expressions', function() {
+
+      const pass = parser.parse('auth.bar[\'foo\' + \'bar\'] != null', []);
+      const scope = {auth: {bar: {foobar: true}}};
+
+      expect(() => pass.evaluate(scope)).to.not.throw();
+      expect(pass.evaluate(scope)).to.be.true();
+
+    });
+
     describe('with logical expression', function() {
 
       it('should evaluate each branch lazily', function() {


### PR DESCRIPTION
Without this change, computed member expressions throw on parse.