### PR TITLE
fix: allow literal computed property access (#115)

### DIFF
--- a/lib/parser/statement/base.js
+++ b/lib/parser/statement/base.js
@@ -51,6 +51,15 @@ class Node {
   }
 
   /**
+   * AST node type.
+   *
+   * @return {string} This expression node type
+   */
+  get type() {
+    return this.astNode.type;
+  }
+
+  /**
    * Hook called before type inferring.
    *
    * Should be used to setup children nodes.

--- a/lib/parser/statement/member.js
+++ b/lib/parser/statement/member.js
@@ -83,10 +83,6 @@ class MemberNode extends Node {
 
     this.assertType(objectType, ['RuleDataSnapshot', 'string'], {msg});
 
-    if (objectType === 'RuleDataSnapshot' && this.computed) {
-      throw new ParseError(this, 'Invalid property access');
-    }
-
     if (types.isPrimitive(objectType)) {
       objectType = this.object.inferredType = 'string';
     }
@@ -111,7 +107,27 @@ class MemberNode extends Node {
   }
 
   inferType() {
-    return this.computed ? 'any' : this.property.inferredType;
+    if (!this.computed) {
+      return this.property.inferredType;
+    }
+
+    if (this.property.type !== 'Literal') {
+      return 'any';
+    }
+
+    const scope = MemberNode.properties[this.object.inferredType];
+
+    if (scope == null) {
+      return 'any';
+    }
+
+    const type = scope[this.property.value];
+
+    if (type == null) {
+      throw new ParseError(this, 'Invalid property access.');
+    }
+
+    return type;
   }
 
   inferAsStringMethod() {

--- a/test/spec/lib/parser/fixtures.json
+++ b/test/spec/lib/parser/fixtures.json
@@ -1062,6 +1062,26 @@
       "user": "unauth",
       "isValid": true,
       "failAtRuntime": true
+    },
+    {
+      "rule": "root[\"exists\"]() == false",
+      "user": "unauth",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "root[\"exi\" + \"sts\"]() == false",
+      "user": "unauth",
+      "isValid": false
+    },
+    {
+      "rule": "root[$foo]() == false",
+      "user": "unauth",
+      "wildchildren": {
+        "$foo": "exists"
+      },
+      "isValid": false
     }
   ]
 }


### PR DESCRIPTION
Firebase allows RuleDataSnapshot via computed property if the property is a literal node:

- `root["exists”]()` is allowed;
- `root["exi" + "sts”]()` is not allowed;
- `root[$foo]()` is not allowed.