### PR TITLE
chore: better property access error message

### DIFF
--- a/lib/parser/statement/member.js
+++ b/lib/parser/statement/member.js
@@ -111,20 +111,27 @@ class MemberNode extends Node {
       return this.property.inferredType;
     }
 
-    if (this.property.type !== 'Literal') {
+    const msg = 'Invalid property access.';
+    const objectType = this.object.inferredType;
+
+    if (types.isFuzzy(objectType)) {
       return 'any';
     }
 
-    const scope = MemberNode.properties[this.object.inferredType];
+    if (this.property.type !== 'Literal') {
+      throw new ParseError(this, msg);
+    }
+
+    const scope = MemberNode.properties[objectType];
 
     if (scope == null) {
-      return 'any';
+      throw new ParseError(this, msg);
     }
 
     const type = scope[this.property.value];
 
     if (type == null) {
-      throw new ParseError(this, 'Invalid property access.');
+      throw new ParseError(this, msg);
     }
 
     return type;

--- a/test/spec/lib/parser/fixtures.json
+++ b/test/spec/lib/parser/fixtures.json
@@ -1071,6 +1071,11 @@
       "evaluateTo": true
     },
     {
+      "rule": "root[\"doesNotExist\"]() == true",
+      "user": "unauth",
+      "isValid": false
+    },
+    {
       "rule": "root[\"exi\" + \"sts\"]() == false",
       "user": "unauth",
       "isValid": false


### PR DESCRIPTION
Throw during in the inferring type of computed property instead of letting the call expression parsing do it later.