### PR TITLE
fix: literal computed property access on string

### DIFF
--- a/lib/parser/statement/member.js
+++ b/lib/parser/statement/member.js
@@ -140,13 +140,11 @@ class MemberNode extends Node {
   inferAsStringMethod() {
     this.object.inferredType = 'string';
 
-    if (this.computed) {
-      return 'any';
+    if (!this.computed) {
+      this.property.inferredType = this.property.inferType(scopeFactory.create(MemberNode.properties.string));
     }
 
-    this.property.inferredType = this.property.inferType(scopeFactory.create(MemberNode.properties.string));
-
-    return this.property.inferredType;
+    return this.inferType();
   }
 
   evaluate(state) {

--- a/test/spec/lib/parser/fixtures.json
+++ b/test/spec/lib/parser/fixtures.json
@@ -1087,6 +1087,18 @@
         "$foo": "exists"
       },
       "isValid": false
+    },
+    {
+      "rule": "auth.someString[\"contains\"](\"on\") == true",
+      "user": "bob",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "auth.someString[\"doesNotContains\"](\"on\") == false",
+      "user": "bob",
+      "isValid": false
     }
   ]
 }


### PR DESCRIPTION
Allow computed property access on fuzzy typed object when the property is literal matching a string method name.

Related to #115.