### PR TITLE
Add support for "query" variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ npm install targaryen@3
 
     Extends the database object with auth data.
 
-- `Database.prototype.read(path: string, now: null|number): Result`
+- `Database.prototype.read(path: string, options: {now: number, query: object}): Result`
 
     Simulates a read operation.
 
-- `Database.prototype.write(path: string, value: any, priority: any, now: null|number): Result`
+- `Database.prototype.write(path: string, value: any, options: {now: number, priority: any}): Result`
 
     Simulates a write operation.
 
-- `Database.prototype.update(path: string, patch: object, now: null|number): Result`
+- `Database.prototype.update(path: string, patch: object, options: {now: number}): Result`
 
     Simulates an update operation (including multi-location update).
 

--- a/docs/chai/README.md
+++ b/docs/chai/README.md
@@ -66,7 +66,8 @@ mocha examples/<name of example>.js
 - `chai.Assertion.can`: asserts that this is an affirmative test, i.e., the specified operation ought to succeed.
 - `chai.Assertion.cannot`: asserts that this is a negative test, i.e., the specified operation ought to fail.
 - `chai.Assertion.read`: asserts that this test is for a read operation.
-- `chai.Assertion.write(data: any)`: asserts that this test is for a write operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
-- `chai.Assertion.patch(data: {[path: string]: any})`: asserts that this test is for a patch (or multi-location update) operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
+- `chai.Assertion.readWith(options: {query: object, now: number})`: asserts that this test is for a read operation.
+- `chai.Assertion.write(data: any [, options: {now: number, priority: any}])`: asserts that this test is for a write operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
+- `chai.Assertion.patch(data: {[path: string]: any} [, options: {now: number}])`: asserts that this test is for a patch (or multi-location update) operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
 - `chai.Assertion.path(firebasePath: string)`: asserts the path against which the operation should be conducted. This method actually tries the damn operation.
 

--- a/docs/chai/README.md
+++ b/docs/chai/README.md
@@ -51,10 +51,10 @@ mocha examples/<name of example>.js
 
 - import with `require('targaryen/plugins/chai')`.
 - `chaiTargaryen.chai`: The plugin object. Load this using `chai.use(chaiTargaryen.chai)` before running any tests.
-- `chaiTargaryen.setFirebaseData(data)`: Set the mock data to be used as the existing Firebase data, i.e., `root` and `data`.
-- `chaiTargaryen.setFirebaseRules(rules)`: Set the security rules to be tested against. Throws if there's a syntax error in your rules.
-- `chaiTargaryen.setDebug(flag)`: Failed expectations will show the result of each rule when debug is set to `true` (`true` by default).
-- `chaiTargaryen.setVerbose(flag)`: Failed expectations will show the detailed evaluation of each rule when verbose is set to `true`(`true` by default).
+- `chaiTargaryen.setFirebaseData(data: any)`: Set the mock data to be used as the existing Firebase data, i.e., `root` and `data`.
+- `chaiTargaryen.setFirebaseRules(rules: object)`: Set the security rules to be tested against. Throws if there's a syntax error in your rules.
+- `chaiTargaryen.setDebug(flag: boolean)`: Failed expectations will show the result of each rule when debug is set to `true` (`true` by default).
+- `chaiTargaryen.setVerbose(flag: boolean)`: Failed expectations will show the detailed evaluation of each rule when verbose is set to `true`(`true` by default).
 - `chaiTargaryen.users`: A set of authentication objects you can use as the subject of the assertions. Has the following keys:
   - `unauthenticated`: an unauthenticated user, i.e., `auth === null`.
   - `anonymous`: a user authenticated using Firebase anonymous sessions.
@@ -66,7 +66,7 @@ mocha examples/<name of example>.js
 - `chai.Assertion.can`: asserts that this is an affirmative test, i.e., the specified operation ought to succeed.
 - `chai.Assertion.cannot`: asserts that this is a negative test, i.e., the specified operation ought to fail.
 - `chai.Assertion.read`: asserts that this test is for a read operation.
-- `chai.Assertion.write(data)`: asserts that this test is for a write operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
-- `chai.Assertion.patch(data)`: asserts that this test is for a patch (or multi-location update) operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
-- `chai.Assertion.path(firebasePath)`: asserts the path against which the operation should be conducted. This method actually tries the damn operation.
+- `chai.Assertion.write(data: any)`: asserts that this test is for a write operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
+- `chai.Assertion.patch(data: {[path: string]: any})`: asserts that this test is for a patch (or multi-location update) operation. Optionally takes a Javascript object or primitive with the new data to be written (which will be in the `newData` snapshot in the rules). Otherwise it just tries with `null`.
+- `chai.Assertion.path(firebasePath: string)`: asserts the path against which the operation should be conducted. This method actually tries the damn operation.
 

--- a/docs/jasmine/README.md
+++ b/docs/jasmine/README.md
@@ -62,10 +62,10 @@ jasmine spec/security/<name of example>.js
   - `twitter`: a user authenticated by their Twitter account.
   - `google`: a user authenticated by their Google account.
   - `github`: a user authenticated by their Github account.
-- `expect(auth).canRead(path: string)`: asserts that the given path is readable by a user with the given authentication data.
-- `expect(auth).cannotRead(path: string)`: asserts that the given path is not readable by a user with the given authentication data.
-- `expect(auth).canWrite(path: string, data: any)`: asserts that the given path is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
-- `expect(auth).cannotWrite(path: string, data: any)`: asserts that the given path is not writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
-- `expect(auth).canPatch(path: string, patch: {[path: string]: any})`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data.
-- `expect(auth).cannotPatch(path: string, patch: {[path: string]: any})`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data.
+- `expect(auth).canRead(path: string [, options: {now?: number, query?: object} ])`: asserts that the given path is readable by a user with the given authentication data.
+- `expect(auth).cannotRead(path: string[, options: {now?: number, query?: object} ])`: asserts that the given path is not readable by a user with the given authentication data.
+- `expect(auth).canWrite(path: string [, data: any [, options: {now: number, priority: any} ]])`: asserts that the given path is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).cannotWrite(path: string [, data: any [, options: {now: number, priority: any} ]])`: asserts that the given path is not writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).canPatch(path: string, patch: {[path: string]: any} [, options: {now: number} ])`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data.
+- `expect(auth).cannotPatch(path: string, patch: {[path: string]: any} [, options: {now: number} ])`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data.
 

--- a/docs/jasmine/README.md
+++ b/docs/jasmine/README.md
@@ -50,10 +50,10 @@ jasmine spec/security/<name of example>.js
 
 - import with `require('targaryen/plugins/jasmine')`.
 - `jasmineTargaryen.matchers`: The plugin object. Load this using `jasmine.addMatchers(jasmineTargaryen.matchers)` before running any tests.
-- `jasmineTargaryen.setFirebaseData(data)`: Set the mock data to be used as the existing Firebase data, i.e., `root` and `data`.
-- `jasmineTargaryen.setFirebaseRules(rules)`: Set the security rules to be tested against. Throws if there's a syntax error in your rules.
-- `jasmineTargaryen.setDebug(flag)`: Failed expectations will show the result of each rule when debug is set to `true` (`true` by default).
-- `jasmineTargaryen.setVerbose(flag)`: Failed expectations will show the detailed evaluation of each rule when verbose is set to `true`(`true` by default).
+- `jasmineTargaryen.setFirebaseData(data: any)`: Set the mock data to be used as the existing Firebase data, i.e., `root` and `data`.
+- `jasmineTargaryen.setFirebaseRules(rules: object)`: Set the security rules to be tested against. Throws if there's a syntax error in your rules.
+- `jasmineTargaryen.setDebug(flag: boolean)`: Failed expectations will show the result of each rule when debug is set to `true` (`true` by default).
+- `jasmineTargaryen.setVerbose(flag: boolean)`: Failed expectations will show the detailed evaluation of each rule when verbose is set to `true`(`true` by default).
 - `jasmineTargaryen.users`: A set of authentication objects you can use as the subject of the assertions. Has the following keys:
   - `unauthenticated`: an unauthenticated user, i.e., `auth === null`.
   - `anonymous`: a user authenticated using Firebase anonymous sessions.
@@ -62,10 +62,10 @@ jasmine spec/security/<name of example>.js
   - `twitter`: a user authenticated by their Twitter account.
   - `google`: a user authenticated by their Google account.
   - `github`: a user authenticated by their Github account.
-- `expect(auth).canRead(path)`: asserts that the given path is readable by a user with the given authentication data.
-- `expect(auth).cannotRead(path)`: asserts that the given path is not readable by a user with the given authentication data.
-- `expect(auth).canWrite(path, data)`: asserts that the given path is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
-- `expect(auth).cannotWrite(path, data)`: asserts that the given path is not writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
-- `expect(auth).canPatch(patch, data)`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
-- `expect(auth).cannotPatch(patch, data)`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).canRead(path: string)`: asserts that the given path is readable by a user with the given authentication data.
+- `expect(auth).cannotRead(path: string)`: asserts that the given path is not readable by a user with the given authentication data.
+- `expect(auth).canWrite(path: string, data: any)`: asserts that the given path is writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).cannotWrite(path: string, data: any)`: asserts that the given path is not writable by a user with the given authentication data. Optionally takes a Javascript object containing `newData`, otherwise this will be set to `null`.
+- `expect(auth).canPatch(path: string, patch: {[path: string]: any})`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data.
+- `expect(auth).cannotPatch(path: string, patch: {[path: string]: any})`: asserts that the given patch (or multi-location update) operation is writable by a user with the given authentication data.
 

--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const paths = require('../paths');
+const query = require('./query');
 const store = require('./store');
 const ruleset = require('./ruleset');
 const results = require('./results');
@@ -375,6 +376,7 @@ exports.snapshot = function(path, value, now) {
 };
 
 // aliases
+exports.query = query.create;
 exports.store = store.create;
 exports.ruleset = ruleset.create;
 exports.results = {

--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -101,11 +101,13 @@ class Database {
    * Simulate a read operation.
    *
    * @param  {string} path  Path to read
-   * @param  {number}  [now] Operation current time stamp
+   * @param  {number|{now: number, query: object}}  [nowOrOptions] Read options
    * @return {Result}
    */
-  read(path, now) {
-    return this.rules.tryRead(path, this, now);
+  read(path, nowOrOptions) {
+    const options = typeof nowOrOptions === 'number' ? {now: nowOrOptions} : nowOrOptions;
+
+    return this.rules.tryRead(path, this, options);
   }
 
   /**
@@ -113,17 +115,27 @@ class Database {
    *
    * @param  {string} path       The location of the value to replace
    * @param  {any}    value      The replacement value
-   * @param  {any}    [priority] The node priority
-   * @param  {number} [now]      This update timestamp
+   * @param  {number|string|boolean|{priority: any, now: number}} [priorityOrOptions] Node priority or operation options
+   * @param  {number} [nowArg]   Operation current timestamp
    * @return {Result}
    */
-  write(path, value, priority, now) {
-    now = now || Date.now();
+  write(path, value, priorityOrOptions, nowArg) {
+    let priority = priorityOrOptions;
+    let now = nowArg;
+
+    if (priorityOrOptions && typeof priorityOrOptions === 'object') {
+      priority = priorityOrOptions.priority;
+      now = priorityOrOptions.now;
+    }
+
+    if (!now) {
+      now = Date.now();
+    }
 
     const newRoot = this.root.$set(path, value, priority, now);
     const newData = this.with({data: newRoot, now});
 
-    return this.rules.tryWrite(path, this, newData, value, now);
+    return this.rules.tryWrite(path, this, newData, value);
   }
 
   /**
@@ -137,18 +149,18 @@ class Database {
    *
    * @param  {string}      path  Path to the node to write
    * @param  {object}      patch Map of path/value to update the database.
-   * @param  {number}      [now] Timestamp of the write operation
+   * @param  {number|{now: number}}  [nowOrOptions] Operation current timestamp or options
    * @return {{info: string, allowed: boolean}}
    */
-  update(path, patch, now) {
-
-    now = now || Date.now();
-
+  update(path, patch, nowOrOptions) {
+    const now = typeof nowOrOptions === 'number' ?
+      nowOrOptions :
+      nowOrOptions && nowOrOptions.now ? nowOrOptions.now : Date.now();
     const data = this.root.$merge(path, patch, now);
     const newDatabase = this.with({data, now});
     const pathsToTest = Object.keys(patch).map(endPath => paths.join(path, endPath));
     const writeResults = pathsToTest.map(
-      p => this.rules.tryWrite(p, this, newDatabase, patch, now)
+      p => this.rules.tryWrite(p, this, newDatabase, patch)
     );
 
     return results.update(path, this, patch, writeResults);

--- a/lib/database/query.js
+++ b/lib/database/query.js
@@ -1,0 +1,214 @@
+/**
+ * Create a query object with its default values.
+ */
+
+'use strict';
+
+const orderedBy = Symbol('orderBy');
+const orderByKey = Symbol('orderByKey');
+const orderByValue = Symbol('orderByValue');
+const orderByPriority = Symbol('orderByPriority');
+
+/**
+ * Holds read query parameters.
+ */
+class Query {
+
+  get orderByKey() {
+    return this[orderedBy] === orderByKey;
+  }
+
+  get orderByValue() {
+    return this[orderedBy] === orderByValue;
+  }
+
+  get orderByPriority() {
+    return this[orderedBy] === orderByPriority;
+  }
+
+  get orderByChild() {
+    const value = this[orderedBy];
+
+    return typeof value === 'string' ? value : null;
+  }
+
+  /**
+   * Creates an instance of Query.
+   *
+   * @param {Partial<Query>} query Query parameters.
+   */
+  constructor(query) {
+    this[orderedBy] = orderByKey;
+    this.startAt = null;
+    this.endAt = null;
+    this.equalTo = null;
+    this.limitToFirst = null;
+    this.limitToLast = null;
+
+    mergeQueries(this, query);
+    Object.freeze(this);
+  }
+
+  /**
+   * Convert Query to Firebase REST parameters.
+   *
+   * @returns {object}
+   */
+  toParams() {
+    const orderBy = orderByParam(this);
+    const seed = orderBy == null ? {} : {orderBy: JSON.stringify(orderBy)};
+
+    return [
+      'startAt',
+      'endAt',
+      'equalTo',
+      'limitToFirst',
+      'limitToLast'
+    ].reduce((q, key) => {
+      const value = this[key];
+
+      if (value != null) {
+        q[key] = JSON.stringify(value);
+      }
+
+      return q;
+    }, seed);
+  }
+}
+
+/**
+ * Return a Query object.
+ *
+ * @param {Partial<Query>} query Partial query parameters
+ * @returns {Query}
+ */
+exports.create = function(query) {
+  return new Query(query);
+};
+
+/**
+ * Validate and merge partial query parameters to a query object.
+ *
+ * @param {Query} query Query to merges properties to
+ * @param {Partial<Query>} options Partial query parameters
+ * @returns {Query}
+ */
+function mergeQueries(query, options) {
+  if (options == null) {
+    return query;
+  }
+
+  Object.keys(options).forEach(key => {
+    let label = key;
+    let value = options[key];
+
+    validateProp(key, value);
+
+    switch (key) {
+    case 'orderByKey':
+      label = orderedBy;
+      value = orderByKey;
+      break;
+
+    case 'orderByPriority':
+      label = orderedBy;
+      value = orderByPriority;
+      break;
+
+    case 'orderByValue':
+      label = orderedBy;
+      value = orderByValue;
+      break;
+
+    case 'orderByChild':
+      label = orderedBy;
+      break;
+
+    default:
+      break;
+    }
+
+    query[label] = value;
+  });
+
+  return query;
+}
+
+/**
+ * Validate a query property
+ *
+ * @param {string} key Property name
+ * @param {any} value Property value
+ */
+function validateProp(key, value) {
+  const type = typeof value;
+
+  switch (key) {
+  case 'orderByKey':
+  case 'orderByPriority':
+  case 'orderByValue':
+    if (!value) {
+      throw new Error(`"query.${key}" should not be set to false. Set it off by setting an other order.`);
+    }
+    break;
+
+  case 'orderByChild':
+    if (value == null) {
+      throw new Error('"query.orderByChild" should not be set to null. Set it off by setting an other order.');
+    }
+    if (type !== 'string') {
+      throw new Error('"query.orderByChild" should be a string or null.');
+    }
+    break;
+
+  case 'startAt':
+  case 'endAt':
+  case 'equalTo':
+    if (
+      value !== null &&
+      type !== 'string' &&
+      type !== 'number' &&
+      type !== 'boolean'
+    ) {
+      throw new Error(`query.${key} should be a string, a number, a boolean or null.`);
+    }
+    break;
+
+  case 'limitToFirst':
+  case 'limitToLast':
+    if (value != null && type !== 'number') {
+      throw new Error(`query.${key} should be a number or null.`);
+    }
+    break;
+
+  default:
+    throw new Error(`"${key}" is not a query parameter.`);
+  }
+}
+
+/**
+ * Returns the property to order by or the ordering keyword ("$value" or
+ * "$priority").
+ *
+ * Never return "$key" since it's the default ordering.
+ *
+ * @param {Query} query Query to find ordering for.
+ * @returns {string|void}
+ */
+function orderByParam(query) {
+  const value = query[orderedBy];
+
+  switch (value) {
+  case orderByKey:
+    return;
+
+  case orderByValue:
+    return '$value';
+
+  case orderByPriority:
+    return '$priority';
+
+  default:
+    return value;
+  }
+}

--- a/lib/database/ruleset.js
+++ b/lib/database/ruleset.js
@@ -52,7 +52,7 @@ function testRuleType(stack, kind, value) {
     }
 
     if (Array.isArray(value) && value.some(i => typeof i !== 'string')) {
-      throw new RuleError(stack, `Expected .indexOn an Array of string, got ${value.map(x => typeof x).join(', ')}`);
+      throw new RuleError(stack, `Expected .indexOn to be an Array of string, got ${value.map(x => typeof x).join(', ')}`);
     }
 
     return;
@@ -61,8 +61,9 @@ function testRuleType(stack, kind, value) {
   case '.write':
   case '.validate':
     if (ruleType !== 'string' && ruleType !== 'boolean') {
-      throw new RuleError(stack, `Expected .indexOn to be a string or a boolean, got ${ruleType}`);
+      throw new RuleError(stack, `Expected ${kind} to be a string or a boolean, got ${ruleType}`);
     }
+
     return;
 
   default:

--- a/lib/database/ruleset.js
+++ b/lib/database/ruleset.js
@@ -6,6 +6,7 @@
 
 const parser = require('../parser');
 const paths = require('../paths');
+const dbQuery = require('./query');
 const results = require('./results');
 
 /**
@@ -116,10 +117,12 @@ class Ruleset {
    *
    * @param  {string}      path  Path to the node to read
    * @param  {Database}    data  Database to read
-   * @param  {number}      [now] Timestamp of the read operation
+   * @param  {{now: number, query: object}} [options] Read options
    * @return {{info: string, allowed: boolean}}
    */
-  tryRead(path, data, now) {
+  tryRead(path, data, options) {
+    const now = options && options.now;
+    const query = dbQuery.create(options && options.query);
 
     paths.mustBeValid(path);
 
@@ -127,6 +130,7 @@ class Ruleset {
     let state = {
       root: data.snapshot('/'),
       auth: result.auth,
+      query,
       now
     };
 

--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -8,6 +8,7 @@ const FirebaseTokenGenerator = require('firebase-token-generator');
 const fs = require('fs');
 const log = require('debug')('targaryen:firebase');
 const path = require('path');
+const qs = require('querystring');
 const request = require('request-promise-native');
 
 const SECRET_PATH = process.env.TARGARYEN_SECRET_PATH || path.resolve('targaryen-secret.json');
@@ -147,20 +148,20 @@ exports.tokens = function(users, options) {
  *
  * @param  {string} path    Path to read.
  * @param  {string} token   Legacy id token to use.
- * @param  {{secret: {projectId: string}}} options Client options
+ * @param  {{secret: {projectId: string}, query: object}} options Client options
  * @return {Promise<boolean,Error>}
  */
 exports.canRead = function(path, token, options) {
   options = options || {};
 
   return loadSecret(options).then(secret => {
-    const databaseURL = `https://${secret.projectId}.firebaseio.com`;
-
-    const auth = token ? `?auth=${token}` : '';
-    const uri = `${databaseURL}/${path}.json${auth}`;
     const method = 'GET';
+    const databaseURL = `https://${secret.projectId}.firebaseio.com`;
+    const query = prepareQuery(options.query, token);
+    const uri = `${databaseURL}/${path}.json?${qs.stringify(query)}`;
+    const logURI = `${databaseURL}/${path}.json?${qs.stringify(secureQuery(query))}`;
 
-    log(`${method} ${databaseURL}/${path}.json${auth.slice(0, 6)}`);
+    log(`${method} ${logURI}`);
 
     return request({uri, method}).then(
       () => true,
@@ -174,3 +175,53 @@ exports.canRead = function(path, token, options) {
     );
   });
 };
+
+function prepareQuery(query, token) {
+  const result = Object.keys(query || {}).reduce((q, key) => {
+    switch (key) {
+    case 'orderByChild':
+      q.orderBy = JSON.stringify(query.orderByChild);
+      break;
+
+    case 'orderByKey':
+      q.orderBy = '"$key"';
+      break;
+
+    case 'orderByPriority':
+      q.orderBy = '"$priority"';
+      break;
+
+    case 'orderByValue':
+      q.orderBy = '"$value"';
+      break;
+
+    case 'orderBy':
+    case 'startAt':
+    case 'endAt':
+    case 'limitToFirst':
+    case 'limitToLast':
+    case 'equalTo':
+      q[key] = JSON.stringify(query[key]);
+      break;
+
+    default:
+      break;
+    }
+
+    return q;
+  }, {});
+
+  if (token) {
+    result.auth = token;
+  }
+
+  return result;
+}
+
+function secureQuery(query) {
+  return Object.assign(
+    {},
+    query,
+    query.auth == null ? {} : {auth: query.auth.slice(0, 6)}
+  );
+}

--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -11,6 +11,8 @@ const path = require('path');
 const qs = require('querystring');
 const request = require('request-promise-native');
 
+const dbQuery = require('./database/query');
+
 const SECRET_PATH = process.env.TARGARYEN_SECRET_PATH || path.resolve('targaryen-secret.json');
 let CACHED_SECRET;
 
@@ -177,39 +179,7 @@ exports.canRead = function(path, token, options) {
 };
 
 function prepareQuery(query, token) {
-  const result = Object.keys(query || {}).reduce((q, key) => {
-    switch (key) {
-    case 'orderByChild':
-      q.orderBy = JSON.stringify(query.orderByChild);
-      break;
-
-    case 'orderByKey':
-      q.orderBy = '"$key"';
-      break;
-
-    case 'orderByPriority':
-      q.orderBy = '"$priority"';
-      break;
-
-    case 'orderByValue':
-      q.orderBy = '"$value"';
-      break;
-
-    case 'orderBy':
-    case 'startAt':
-    case 'endAt':
-    case 'limitToFirst':
-    case 'limitToLast':
-    case 'equalTo':
-      q[key] = JSON.stringify(query[key]);
-      break;
-
-    default:
-      break;
-    }
-
-    return q;
-  }, {});
+  const result = dbQuery.create(query).toParams();
 
   if (token) {
     result.auth = token;

--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -82,13 +82,7 @@ exports.deployRules = function(rules, options) {
     const method = 'PUT';
     const body = typeof rules === 'string' ? rules : JSON.stringify({rules}, undefined, 2);
 
-    return request({uri, method, body}).catch(e => {
-      if (e.statusCode != null) {
-        return Promise.reject(new Error(e.message));
-      }
-
-      return Promise.reject(e);
-    });
+    return request({uri, method, body});
   });
 };
 
@@ -112,13 +106,7 @@ exports.deployData = function(data, options) {
     const method = 'PUT';
     const body = JSON.stringify(data || null);
 
-    return request({uri, method, body}).catch(e => {
-      if (e.statusCode != null) {
-        return Promise.reject(new Error(e.message));
-      }
-
-      return Promise.reject(e);
-    });
+    return request({uri, method, body});
   });
 };
 
@@ -179,10 +167,6 @@ exports.canRead = function(path, token, options) {
       e => {
         if (e.statusCode === 403 || e.statusCode === 401) {
           return false;
-        }
-
-        if (e.statusCode != null) {
-          return Promise.reject(new Error(e.message));
         }
 
         return Promise.reject(e);

--- a/lib/parser/scope.js
+++ b/lib/parser/scope.js
@@ -67,7 +67,8 @@ class Scope {
       auth: 'any',
       root: 'RuleDataSnapshot',
       data: 'RuleDataSnapshot',
-      now: 'number'
+      now: 'number',
+      query: 'Query'
     };
   }
 

--- a/lib/parser/specs.js
+++ b/lib/parser/specs.js
@@ -75,6 +75,7 @@ class RuleSpec {
     this.user = details.user;
     this.wildchildren = details.wildchildren;
     this.data = details.data;
+    this.query = details.query;
     this.isValid = undefined;
     this.failAtRuntime = undefined;
     this.evaluateTo = undefined;
@@ -85,7 +86,21 @@ class RuleSpec {
       .sort((a, b) => a.localeCompare(b))
       .join('.');
 
-    return set({}, `${path}[".read"]`, this.rule);
+    const rules = set({}, `${path}[".read"]`, this.rule);
+
+    if (!this.query) {
+      return rules;
+    }
+
+    if (this.query.orderByChild) {
+      return set(rules, `${path}[".indexOn"]`, this.query.orderByChild);
+    }
+
+    if (this.query.orderByValue) {
+      return set(rules, `${path}[".indexOn"]`, '.value');
+    }
+
+    return rules;
   }
 
   get path() {
@@ -187,15 +202,17 @@ class RuleSpec {
 
     log('  evaluating rule...');
 
-    return firebase.canRead(this.path, token).then(result => {
-      this.evaluateTo = result;
+    return firebase.canRead(this.path, token, {query: this.query})
+      .then(result => {
+        this.evaluateTo = result;
 
-      log(`    evaluates to: ${result}`);
+        log(`    evaluates to: ${result}`);
 
-      return result;
-    }).catch(
-      e => Promise.reject(e.message || e.toString())
-    );
+        return result;
+      }).catch(
+        e => Promise.reject(e.message || e.toString())
+      );
+
   }
 
   /**

--- a/lib/parser/specs.js
+++ b/lib/parser/specs.js
@@ -120,16 +120,14 @@ class RuleSpec {
       () => true,
       e => {
         if (e.statusCode !== 400 || e.error === 'Could not parse auth token.') {
-          return Promise.reject(e);
+          return Promise.reject(e.message || e.toString());
         }
 
-        let msg;
-
         try {
-          msg = JSON.parse(e.error).error.trim();
-        } catch (e) {}
-
-        error(msg || e);
+          error(JSON.parse(e.error).error.trim());
+        } catch (parseErr) {
+          error(e.message || e.toString());
+        }
 
         return false;
       }
@@ -157,6 +155,8 @@ class RuleSpec {
 
     return firebase.deployData(this.data || null).then(
       () => log('  data deployed.')
+    ).catch(
+      e => Promise.reject(e.message || e.toString())
     );
   }
 
@@ -193,7 +193,9 @@ class RuleSpec {
       log(`    evaluates to: ${result}`);
 
       return result;
-    });
+    }).catch(
+      e => Promise.reject(e.message || e.toString())
+    );
   }
 
   /**

--- a/lib/parser/specs.js
+++ b/lib/parser/specs.js
@@ -287,6 +287,7 @@ class RuleSpec {
     }
 
     const state = Object.assign({
+      query: database.query(this.query),
       root: database.snapshot('/', this.data || null),
       now: Date.now(),
       auth: users[this.user] || null

--- a/lib/parser/statement/member.js
+++ b/lib/parser/statement/member.js
@@ -17,6 +17,18 @@ class MemberNode extends Node {
   static get properties() {
     return {
 
+      Query: {
+        orderByKey: 'boolean',
+        orderByPriority: 'boolean',
+        orderByValue: 'boolean',
+        orderByChild: 'string',
+        startAt: 'primitive',
+        endAt: 'primitive',
+        equalTo: 'primitive',
+        limitToFirst: 'number',
+        limitToLast: 'number'
+      },
+
       string: {
         contains: {name: 'contains', args: ['string'], returnType: 'boolean'},
         beginsWith: {name: 'beginsWith', args: ['string'], returnType: 'boolean'},
@@ -81,7 +93,7 @@ class MemberNode extends Node {
     const msg = `No such method/property ${this.astNode.property.name}`;
     let objectType = this.object.inferredType;
 
-    this.assertType(objectType, ['RuleDataSnapshot', 'string'], {msg});
+    this.assertType(objectType, ['Query', 'RuleDataSnapshot', 'string'], {msg});
 
     if (types.isPrimitive(objectType)) {
       objectType = this.object.inferredType = 'string';

--- a/plugins/chai.js
+++ b/plugins/chai.js
@@ -23,37 +23,49 @@ function chaiTargaryen(chai, utils) {
   });
 
   chai.Assertion.addChainableMethod('readAt', function(now) {
+    const options = Object.assign({}, utils.flag(this, 'operationOptions'), {now});
 
     utils.flag(this, 'operation', 'read');
-    utils.flag(this, 'operationTimestamp', now);
+    utils.flag(this, 'operationOptions', options);
+
+  }, function() {
+    const options = Object.assign({}, utils.flag(this, 'operationOptions'), {now: null});
+
+    utils.flag(this, 'operation', 'read');
+    utils.flag(this, 'operationOptions', options);
+  });
+
+  chai.Assertion.addChainableMethod('readWith', function(options) {
+    utils.flag(this, 'operation', 'read');
+    utils.flag(this, 'operationOptions', options);
 
   }, function() {
     utils.flag(this, 'operation', 'read');
-    utils.flag(this, 'operationTimestamp', null);
+    utils.flag(this, 'operationOptions', {});
   });
 
-  chai.Assertion.addChainableMethod('write', function(data, now) {
+  chai.Assertion.addChainableMethod('write', function(data, options) {
 
     utils.flag(this, 'operation', 'write');
     utils.flag(this, 'operationData', data);
-    utils.flag(this, 'operationTimestamp', now);
+    utils.flag(this, 'operationOptions', typeof options === 'number' ? {now: options} : options);
 
   }, function() {
     utils.flag(this, 'operation', 'write');
     utils.flag(this, 'operationData', null);
-    utils.flag(this, 'operationTimestamp', null);
+    utils.flag(this, 'operationOptions', {});
   });
 
-  chai.Assertion.addChainableMethod('patch', function(data, now) {
+  chai.Assertion.addChainableMethod('patch', function(data, options) {
 
     utils.flag(this, 'operation', 'patch');
     utils.flag(this, 'operationData', data);
-    utils.flag(this, 'operationTimestamp', now);
+    utils.flag(this, 'operationOptions', options);
 
   }, function() {
     utils.flag(this, 'operation', 'patch');
     utils.flag(this, 'operationData', null);
-    utils.flag(this, 'operationTimestamp', null);
+    utils.flag(this, 'operationOptions', {});
   });
 
   chai.Assertion.addMethod('path', function(path) {
@@ -63,14 +75,14 @@ function chaiTargaryen(chai, utils) {
     const auth = this._obj;
     const data = targaryen.util.getFirebaseData().as(auth);
     const operationType = utils.flag(this, 'operation');
-    const now = utils.flag(this, 'operationTimestamp');
+    const options = utils.flag(this, 'operationOptions');
     const positivity = utils.flag(this, 'positivity');
     let result, newData;
 
     switch (operationType) {
 
     case 'read':
-      result = data.read(path, now);
+      result = data.read(path, options);
 
       if (positivity) {
         chai.assert(result.allowed === true, targaryen.util.unreadableError(result, 6).trim());
@@ -82,12 +94,12 @@ function chaiTargaryen(chai, utils) {
 
     case 'write':
       newData = utils.flag(this, 'operationData');
-      result = data.write(path, newData, undefined, now);
+      result = data.write(path, newData, options);
       break;
 
     case 'patch':
       newData = utils.flag(this, 'operationData');
-      result = data.update(path, newData, now);
+      result = data.update(path, newData, options);
       break;
 
     default:

--- a/plugins/jasmine.js
+++ b/plugins/jasmine.js
@@ -19,11 +19,11 @@ exports.matchers = {
 
   canRead() {
 
-    return {compare(auth, path, now) {
+    return {compare(auth, path, options) {
 
       const data = targaryen.util.getFirebaseData().as(auth);
 
-      const result = data.read(path, now);
+      const result = data.read(path, options);
 
       return {
         pass: result.allowed === true,
@@ -35,11 +35,11 @@ exports.matchers = {
   },
   cannotRead() {
 
-    return {compare(auth, path, now) {
+    return {compare(auth, path, options) {
 
       const data = targaryen.util.getFirebaseData().as(auth);
 
-      const result = data.read(path, now);
+      const result = data.read(path, options);
 
       return {
         pass: result.allowed === false,
@@ -51,11 +51,13 @@ exports.matchers = {
   },
   canWrite() {
 
-    return {compare(auth, path, newData, now) {
+    return {compare(auth, path, newData, options) {
 
       const data = targaryen.util.getFirebaseData().as(auth);
 
-      const result = data.write(path, newData, undefined, now);
+      const result = typeof options === 'number' ?
+        data.write(path, newData, undefined, options) :
+        data.write(path, newData, options);
 
       return {
         pass: result.allowed === true,
@@ -67,11 +69,13 @@ exports.matchers = {
   },
   cannotWrite() {
 
-    return {compare(auth, path, newData, now) {
+    return {compare(auth, path, newData, options) {
 
       const data = targaryen.util.getFirebaseData().as(auth);
 
-      const result = data.write(path, newData, undefined, now);
+      const result = typeof options === 'number' ?
+        data.write(path, newData, undefined, options) :
+        data.write(path, newData, options);
 
       return {
         pass: result.allowed === false,
@@ -82,11 +86,11 @@ exports.matchers = {
   },
   canPatch() {
 
-    return {compare(auth, path, newData, now) {
+    return {compare(auth, path, newData, options) {
 
       const data = targaryen.util.getFirebaseData().as(auth);
 
-      const result = data.update(path, newData, now);
+      const result = data.update(path, newData, options);
 
       return {
         pass: result.allowed === true,
@@ -98,11 +102,11 @@ exports.matchers = {
   },
   cannotPatch() {
 
-    return {compare(auth, path, newData, now) {
+    return {compare(auth, path, newData, options) {
 
       const data = targaryen.util.getFirebaseData().as(auth);
 
-      const result = data.update(path, newData, now);
+      const result = data.update(path, newData, options);
 
       return {
         pass: result.allowed === false,

--- a/test/jasmine/core.js
+++ b/test/jasmine/core.js
@@ -114,6 +114,33 @@ describe('the targaryen Jasmine plugin', function() {
       }
     });
 
+    expect(null).canRead('/foo', {now: 1000});
+    expect(null).cannotRead('/foo');
+
+    expect(null).canWrite('/foo', {'.sv': 'timestamp'}, {now: 1000});
+    expect(null).canWrite('/foo', {'.sv': 'timestamp'});
+
+    expect(null).canWrite('/foo', 1000, {now: 1000});
+    expect(null).cannotWrite('/foo', 1000, {now: 2000});
+
+    expect(null).canPatch('/', {foo: {'.sv': 'timestamp'}}, {now: 1000});
+    expect(null).canPatch('/', {foo: {'.sv': 'timestamp'}});
+
+    expect(null).canPatch('/', {foo: 1000}, {now: 1000});
+    expect(null).cannotPatch('/', {foo: 1000}, {now: 2000});
+  });
+
+  it('can set operation time stamp (legacy)', function() {
+    targaryen.setFirebaseData({foo: 2000});
+    targaryen.setFirebaseRules({
+      rules: {
+        $key: {
+          '.read': 'data.val() > now',
+          '.write': 'newData.val() == now'
+        }
+      }
+    });
+
     expect(null).canRead('/foo', 1000);
     expect(null).cannotRead('/foo');
 
@@ -128,6 +155,30 @@ describe('the targaryen Jasmine plugin', function() {
 
     expect(null).canPatch('/', {foo: 1000}, 1000);
     expect(null).cannotPatch('/', {foo: 1000}, 2000);
+  });
+
+  it('can set read query parameters', function() {
+    targaryen.setFirebaseData(null);
+    targaryen.setFirebaseRules({rules: {
+      '.read': 'query.orderByChild == "owner" && query.equalTo == auth.uid'
+    }});
+
+    expect(null).cannotRead('/');
+    expect({uid: 'bob'}).cannotRead('/');
+    expect({uid: 'bob'}).canRead('/', {query: {
+      orderByChild: 'owner',
+      equalTo: 'bob'
+    }});
+  });
+
+  it('can set write priority', function() {
+    targaryen.setFirebaseData(null);
+    targaryen.setFirebaseRules({rules: {
+      '.write': 'newData.getPriority() != null'
+    }});
+
+    expect(null).cannotWrite('/', 'foo');
+    expect(null).canWrite('/', 'foo', {priority: 1});
   });
 
 });

--- a/test/spec/lib/database/query.js
+++ b/test/spec/lib/database/query.js
@@ -1,0 +1,146 @@
+/**
+ * Test firebase query validation.
+ */
+
+'use strict';
+
+const query = require('../../../../lib/database/query');
+
+describe('Query', function() {
+
+  it('should order by key by default', function() {
+    expect(query.create()).to.include({
+      orderByKey: true,
+      orderByPriority: false,
+      orderByValue: false,
+      orderByChild: null
+    });
+  });
+
+  ['orderByKey', 'orderByPriority', 'orderByValue'].forEach(function(order) {
+    it(`should throw when setting ${order} to false`, function() {
+      expect(() => query.create({[order]: false})).to.throw();
+    });
+  });
+
+  it('should throw when setting orderByChild to null', function() {
+    expect(() => query.create({orderByChild: null})).to.throw();
+  });
+
+  it('should set orderBy to orderByKey', function() {
+    expect(query.create({orderByKey: true})).to.include({
+      orderByKey: true,
+      orderByValue: false,
+      orderByPriority: false,
+      orderByChild: null
+    });
+  });
+
+  it('should set orderBy to orderByValue', function() {
+    expect(query.create({orderByValue: true})).to.include({
+      orderByKey: false,
+      orderByValue: true,
+      orderByPriority: false,
+      orderByChild: null
+    });
+  });
+
+  it('should set orderBy to orderByPriority', function() {
+    expect(query.create({orderByPriority: true})).to.include({
+      orderByKey: false,
+      orderByValue: false,
+      orderByPriority: true,
+      orderByChild: null
+    });
+  });
+
+  it('should set orderBy to a child name', function() {
+    expect(query.create({orderByChild: 'foo'})).to.include({
+      orderByKey: false,
+      orderByValue: false,
+      orderByPriority: false,
+      orderByChild: 'foo'
+    });
+  });
+
+  it('should throw if the child name is not a string', function() {
+    expect(() => query.create({orderByChild: 1})).to.throw();
+  });
+
+  ['startAt', 'endAt', 'equalTo'].forEach(function(key) {
+    [null, 'foo', 2, true].forEach(function(value) {
+      it(`should allow to set ${key} to ${value === null ? 'null' : typeof value}`, function() {
+        expect(() => query.create({[key]: value})).not.to.throws();
+      });
+    });
+
+    it(`should throw if setting ${key} to an object`, function() {
+      expect(() => query.create({[key]: {foo: 1}})).to.throws();
+    });
+  });
+
+  ['limitToFirst', 'limitToLast'].forEach(function(key) {
+    [null, 2].forEach(function(value) {
+      it(`should allow to set ${key} to ${value === null ? 'null' : typeof value}`, function() {
+        expect(() => query.create({[key]: value})).not.to.throws();
+      });
+    });
+
+    ['foo', true, {foo: 1}].forEach(function(value) {
+      it(`should throw if setting ${key} to ${Object.isExtensible(value) ? 'object' : typeof value}`, function() {
+        expect(() => query.create({[key]: value})).to.throws();
+      });
+    });
+  });
+
+  it('should throw when setting an unknown property', function() {
+    expect(() => query.create({foo: 1})).to.throws();
+  });
+
+  describe('#toParams', function() {
+    [{
+      msg: 'should return an empty object by default'
+    }, {
+      msg: 'should return order by child params',
+      q: {orderByChild: 'foo'},
+      params: {orderBy: '"foo"'}
+    }, {
+      msg: 'should return order by value params',
+      q: {orderByValue: true},
+      params: {orderBy: '"$value"'}
+    }, {
+      msg: 'should return order by priority params',
+      q: {orderByPriority: true},
+      params: {orderBy: '"$priority"'}
+    }, {
+      msg: 'should return endAt param',
+      q: {endAt: 'foo'},
+      params: {endAt: '"foo"'}
+    }, {
+      msg: 'should return startAt param',
+      q: {startAt: 'foo'},
+      params: {startAt: '"foo"'}
+    }, {
+      msg: 'should return equalTo param',
+      q: {equalTo: 'foo'},
+      params: {equalTo: '"foo"'}
+    }, {
+      msg: 'should return limitToFirst param',
+      q: {limitToFirst: 10},
+      params: {limitToFirst: '10'}
+    }, {
+      msg: 'should return limitToLast param',
+      q: {limitToLast: 10},
+      params: {limitToLast: '10'}
+    }, {
+      msg: 'should return all param',
+      q: {orderByValue: true, startAt: 'foo', endAt: 'bar', limitToLast: 10},
+      params: {orderBy: '"$value"', startAt: '"foo"', endAt: '"bar"', limitToLast: '10'}
+    }].forEach(t => {
+      it(t.msg, function() {
+        expect(query.create(t.q).toParams()).to.eql(t.params || {});
+      });
+    });
+  });
+
+});

--- a/test/spec/lib/parser/fixtures.json
+++ b/test/spec/lib/parser/fixtures.json
@@ -1154,6 +1154,16 @@
       "isValid": true,
       "failAtRuntime": false,
       "evaluateTo": true
+    },
+    {
+      "rule": "query.orderByChild == \"foo/bar\"",
+      "user": "unauth",
+      "query": {
+        "orderByChild": "foo/bar"
+      },
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
     }
   ]
 }

--- a/test/spec/lib/parser/fixtures.json
+++ b/test/spec/lib/parser/fixtures.json
@@ -1164,6 +1164,110 @@
       "isValid": true,
       "failAtRuntime": false,
       "evaluateTo": true
+    },
+    {
+      "rule": "query.orderByChild == null",
+      "user": "unauth",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.orderByChild == \"owner\"",
+      "user": "unauth",
+      "query": {
+        "orderByChild": "owner"
+      },
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.orderByKey == true && query.orderByValue == false && query.orderByPriority == false",
+      "user": "unauth",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.orderByKey != null && query.orderByValue != null && query.orderByPriority != null",
+      "user": "unauth",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.orderByKey == false && query.orderByValue == true && query.orderByPriority == false",
+      "user": "unauth",
+      "query": {
+        "orderByValue": true
+      },
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.startAt == null && query.endAt == null && query.equalTo == null",
+      "user": "unauth",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.startAt == \"foo\"",
+      "user": "unauth",
+      "query": {
+        "orderByValue": true,
+        "startAt": "foo"
+      },
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.endAt == 3",
+      "user": "unauth",
+      "query": {
+        "orderByValue": true,
+        "endAt": 3
+      },
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.equalTo == true",
+      "user": "unauth",
+      "query": {
+        "orderByValue": true,
+        "equalTo": true
+      },
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.limitToLast == null && query.limitToFirst == null",
+      "user": "unauth",
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.limitToLast == 10",
+      "user": "unauth",
+      "query": {
+        "orderByValue": true,
+        "limitToLast": 10
+      },
+      "isValid": true,
+      "failAtRuntime": false,
+      "evaluateTo": true
+    },
+    {
+      "rule": "query.foo == 1",
+      "user": "unauth",
+      "isValid": false
     }
   ]
 }

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -89,6 +89,7 @@ describe('Rule', function() {
 
       fixtures.tests.filter(d => d.isValid && !d.failAtRuntime).forEach(function(details) {
         const state = Object.assign({
+          query: database.query(details.query),
           root: database.snapshot('/', details.data || null),
           now: Date.now(),
           auth: fixtures.users[details.user] || null

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -42,6 +42,45 @@ describe('Rule', function() {
       ).to.throw(/Invalid property access/);
     });
 
+    describe('with query', function() {
+
+      it('should allow access to query attributes', function() {
+        const pass = [
+          'query.orderByChild == "owner"',
+          'query.orderByChild == null',
+          'query.orderByValue',
+          'query.orderByKey',
+          'query.orderByPriority',
+          'query.orderByValue == false',
+          'query.orderByKey == false',
+          'query.orderByPriority == false',
+          'query.startAt == "foo"',
+          'query.endAt == "foo"',
+          'query.equalTo == "foo"',
+          'query.startAt == 3',
+          'query.endAt == 3',
+          'query.equalTo == 3',
+          'query.startAt == true',
+          'query.endAt == true',
+          'query.equalTo == true',
+          'query.startAt == null',
+          'query.endAt == null',
+          'query.equalTo == null',
+          'query.limitToFirst == 10',
+          'query.limitToLast == 10',
+          'query.limitToFirst == null',
+          'query.limitToLast == null'
+        ];
+        const fail = [
+          'query.foo == "owner"'
+        ];
+
+        pass.forEach(rule => expect(() => parser.parse(rule, []), rule).not.to.throw());
+        fail.forEach(rule => expect(() => parser.parse(rule, []), rule).to.throw());
+      });
+
+    });
+
   });
 
   describe('#evaluate', function() {

--- a/test/spec/lib/parser/rule.js
+++ b/test/spec/lib/parser/rule.js
@@ -42,45 +42,6 @@ describe('Rule', function() {
       ).to.throw(/Invalid property access/);
     });
 
-    describe('with query', function() {
-
-      it('should allow access to query attributes', function() {
-        const pass = [
-          'query.orderByChild == "owner"',
-          'query.orderByChild == null',
-          'query.orderByValue',
-          'query.orderByKey',
-          'query.orderByPriority',
-          'query.orderByValue == false',
-          'query.orderByKey == false',
-          'query.orderByPriority == false',
-          'query.startAt == "foo"',
-          'query.endAt == "foo"',
-          'query.equalTo == "foo"',
-          'query.startAt == 3',
-          'query.endAt == 3',
-          'query.equalTo == 3',
-          'query.startAt == true',
-          'query.endAt == true',
-          'query.equalTo == true',
-          'query.startAt == null',
-          'query.endAt == null',
-          'query.equalTo == null',
-          'query.limitToFirst == 10',
-          'query.limitToLast == 10',
-          'query.limitToFirst == null',
-          'query.limitToLast == null'
-        ];
-        const fail = [
-          'query.foo == "owner"'
-        ];
-
-        pass.forEach(rule => expect(() => parser.parse(rule, []), rule).not.to.throw());
-        fail.forEach(rule => expect(() => parser.parse(rule, []), rule).to.throw());
-      });
-
-    });
-
   });
 
   describe('#evaluate', function() {


### PR DESCRIPTION
- [x] support query during parsing.
- [x] support query during evaluation.
- [x] add API to provide query to read operations (and update other operation signature).
  
    ```ts
    Database.prototype.read(path: string, options: {now?: number, query?: object}): Result
    Database.prototype.write(path: string, value: any, options: {now?: number, priority?: any}): Result
    Database.prototype.update(path: string, patch: object, options: {now?: number}): Result
    ```
  
  It's backward compatible with the 3.0.x signature.

- [x] add query to chai matcher:
    
    ```ts
    chai.Assertion.readWith(options: {query?: object, now?: number})
    ```

    e.g.:

    ```js
    expect({uid}).can.readWith({query: {
      orderByChild: 'owner',
      equalTo: uid
    }}).path('/');
    ```
- [x] add query to jasmine matcher.

    ```ts
    expect(auth).canRead(path: string, options: {now?: number, query?: object})
    expect(auth).cannotRead(path: string, options: {now?: number, query?: object})
    ```

    e.g.:

    ```js
    expect({uid}).canRead('/', {query: {
      orderByChild: 'owner',
      equalTo: uid
    }});
    ```

Fix #142