### PR TITLE
Allow dot in literal regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0-beta.2 2018-05-07
+
+- Publish generated regexp parser; Thanks @a-xin for notice it.
+
 ## 3.1.0-beta.1 2018-05-06
 
 - Validate literal regular expression ([#146]).

--- a/lib/parser/regexp/index.js
+++ b/lib/parser/regexp/index.js
@@ -33,6 +33,7 @@ function render(ast, context) {
   case 'char':
     return escape(ast.value, context);
 
+  case 'dot':
   case 'number':
   case 'charset':
     return ast.value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "targaryen",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "description": "Test Firebase security rules without connecting to Firebase.",
   "bin": {
     "targaryen": "bin/targaryen",

--- a/test/spec/lib/parser/regexp.js
+++ b/test/spec/lib/parser/regexp.js
@@ -262,6 +262,10 @@ describe('regexp', function() {
     source: '\\wbc',
     expected: '\\wbc'
   }, {
+    title: 'dot',
+    source: '.bc',
+    expected: '.bc'
+  }, {
     title: 'positive set',
     source: '[-a-z]bc',
     expected: '[-a-z]bc'


### PR DESCRIPTION
They were parsed correctly but it failed to render them to a `RegExp` source.