### PR TITLE
Add jest matcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,9 @@ script:
     fi
   - npm run coveralls
   - npm run lint
+  - >
+    if [[ $(node --version | cut -c 2-) < 6 ]]; then
+      echo "skipping jest plugin test";
+    else
+      npm run test:plugin:jest;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ script:
   - npm run coveralls
   - npm run lint
   - >
-    if [[ $(node --version | cut -c 2-) < 6 ]]; then
-      echo "skipping jest plugin test";
-    else
+    if node --version | grep v6\. ; then
       npm run test:plugin:jest;
+    else
+      echo "skipping jest plugin test";
     fi

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Targaryen provides three convenient ways to run tests:
     });
     ```
 
-- or as a plugin for [Chai](http://chaijs.com).
+- as a plugin for [Chai](http://chaijs.com).
 
     ```js
     const chai = require('chai');
@@ -85,6 +85,29 @@ Targaryen provides three convenient ways to run tests:
       it('should allow authenticated user to read all data', function() {
         expect({uid: 'foo'}).can.read.path('/');
         expect(null).cannot.read.path('/');
+      })
+
+    });
+    ```
+
+- or as a set of custom matchers for [Jest](https://facebook.github.io/jest/):
+
+    ```js
+    const targaryen = require('targaryen/plugins/jest');
+    const rules = targaryen.json.loadSync(RULES_PATH);
+
+    expect.extend({
+      toAllowRead: targaryen.toAllowRead,
+      toAllowUpdate: targaryen.toAllowUpdate,
+      toAllowWrite: targaryen.toAllowWrite
+    });
+
+    describe('my security rules', function() {
+      const database = targaryen.getDatabase(rules, require(DATA_PATH));
+
+      it('should allow authenticated user to read all data', function() {
+        expect(database.as({uid: 'foo'})).toAllowRead('/');
+        expect(database.as(null)).not.toAllowRead('/');
       })
 
     });

--- a/USAGE.md
+++ b/USAGE.md
@@ -166,3 +166,60 @@ describe('A set of rules and data', function() {
 });
 
 ```
+
+### Jest
+
+Docs are at [docs/jest](https://github.com/goldibex/targaryen/blob/master/docs/jest). A quick example:
+
+```js
+
+const targaryen = require('targaryen/plugins/jest');
+
+// see Chai example above for format
+const rules = targaryen.json.loadSync(RULES_PATH);
+const data = require(DATA_PATH);
+
+expect.extend({
+  toAllowRead: targaryen.toAllowRead,
+  toAllowUpdate: targaryen.toAllowUpdate,
+  toAllowWrite: targaryen.toAllowWrite
+});
+
+describe('A set of rules and data', function() {
+  const database = targaryen.getDatabase(rules, data);
+
+  it('should allow authenticated user to read all data', function() {
+    expect(database.as({uid: 'foo'})).toAllowRead('/');
+    expect(database.as(null)).not.toAllowRead('/');
+  })
+
+  it('can be tested', function() {
+
+    expect(database.as(targaryen.users.unauthenticated))
+    .not.toAllowRead('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
+
+    expect(database.as(targaryen.users.password))
+    .toAllowRead('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3');
+
+    expect(database.as(targaryen.users.password))
+    .not.toAllowWrite('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/innocent', true);
+
+    expect(database.as({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d'}))
+    .toAllowWrite('users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/onFire', true);
+
+    expect(database.as({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d'}))
+    .toAllowUpdate('/', {
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/onFire': true,
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/innocent': null
+    });
+
+    expect(database.as({ uid: 'password:3403291b-fdc9-4995-9a54-9656241c835d'}))
+    .not.toAllowUpdate('/', {
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/onFire': null,
+      'users/password:500f6e96-92c6-4f60-ad5d-207253aee4d3/innocent': true
+    });
+
+  });
+
+});
+```

--- a/package.json
+++ b/package.json
@@ -72,9 +72,11 @@
     "coveralls": "^2.11.15",
     "eslint": "^3.9.1",
     "eslint-config-xo": "^0.17.0",
+    "eslint-plugin-jest": "^21.15.1",
     "eslint-plugin-node": "^2.1.3",
     "istanbul": "^0.4.5",
     "jasmine": "^2.1.1",
+    "jest": "^22.4.3",
     "mocha": "^2.1.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepare": "npm run build",
     "test": "npm run build && mocha -r test/setup.js test/spec/ --recursive  && jasmine && node ./bin/targaryen --verbose test/integration/rules.json test/integration/tests.json",
     "test:unit": "mocha -r test/setup.js test/spec/ --recursive",
+    "test:plugin:jest": "jest test/jest",
     "test:inspect": "node --inspect --debug-brk node_modules/.bin/_mocha -r test/setup.js test/spec/ --recursive"
   },
   "author": "Harry Schmidt <me@goldibex.com>",

--- a/plugins/jest.js
+++ b/plugins/jest.js
@@ -1,0 +1,100 @@
+/**
+ * targaryen/plugins/jest - Reference implementation of a jest plugin for
+ * targaryen.
+ *
+ */
+
+'use strict';
+
+const targaryen = require('../');
+
+function toBeAllowed({ info, allowed }) {
+  const pass = allowed === true;
+  const message = pass
+    ? () => `Expected operation to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
+    : () => `Expected operation to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+
+    return {
+    message,
+    pass,
+  };
+}
+
+function toAllowRead(database, path, options) {
+  const { info, allowed } = database
+    .with({ debug: true })
+    .read(path, options);
+
+  const pass = allowed === true;
+  const message = pass
+    ? () => `Expected ${this.utils.EXPECTED_COLOR('read')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
+    : () => `Expected ${this.utils.EXPECTED_COLOR('read')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+
+  return {
+    message,
+    pass,
+  };
+}
+
+function toAllowWrite(database, path, value, options) {
+  const { info, allowed } = database
+    .with({ debug: true })
+    .write(path, value, options);
+
+  const pass = allowed === true;
+  const message = pass
+    ? () => `Expected ${this.utils.EXPECTED_COLOR('write')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
+    : () => `Expected ${this.utils.EXPECTED_COLOR('write')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+
+  return {
+    message,
+    pass,
+  };
+}
+
+function toAllowUpdate(database, path, patch, options) {
+  const { info, allowed } = database
+    .with({ debug: true })
+    .update(path, patch, options);
+
+  const pass = allowed === true;
+  const message = pass
+    ? () => `Expected ${this.utils.EXPECTED_COLOR('update')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
+    : () => `Expected ${this.utils.EXPECTED_COLOR('update')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+
+  return {
+    message,
+    pass,
+  };
+}
+
+/**
+ * Simple wrapper for `targaryen.database()` for conveniently creating a
+ * database for a jest test.
+ */
+function getDatabase(...args) {
+  return targaryen.database(...args);
+}
+
+/**
+ * Simple wrapper for `targaryen.database()` that also enables debug mode for
+ * detailed error messages.
+ */
+function getDebugDatabase(...args) {
+  return targaryen.database(...args).with({ debug: true });
+}
+
+const jestTargaryen = {
+  toBeAllowed,
+  toAllowRead,
+  toAllowWrite,
+  toAllowUpdate,
+
+  // NOTE: Exported for convenience only
+  getDatabase,
+  getDebugDatabase,
+  json: require('firebase-json'),
+  users: targaryen.util.users,
+};
+
+module.exports = jestTargaryen;

--- a/plugins/jest.js
+++ b/plugins/jest.js
@@ -6,82 +6,88 @@
 
 'use strict';
 
+const json = require('firebase-json');
 const targaryen = require('../');
 
-function toBeAllowed({ info, allowed }) {
-  const pass = allowed === true;
-  const message = pass
-    ? () => `Expected operation to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
-    : () => `Expected operation to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+// Need to disable eslint rule for jest's utils: this.utils.EXPECTED_COLOR('a')
+/* eslint-disable new-cap */
 
-    return {
+function toBeAllowed(result) {
+  const pass = result.allowed === true;
+  const message = pass ?
+    () => `Expected operation to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${result.info}` :
+    () => `Expected operation to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${result.info}`;
+
+  return {
     message,
-    pass,
+    pass
   };
 }
 
 function toAllowRead(database, path, options) {
-  const { info, allowed } = database
-    .with({ debug: true })
+  const result = database
+    .with({debug: true})
     .read(path, options);
 
-  const pass = allowed === true;
-  const message = pass
-    ? () => `Expected ${this.utils.EXPECTED_COLOR('read')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
-    : () => `Expected ${this.utils.EXPECTED_COLOR('read')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+  const pass = result.allowed === true;
+  const message = pass ?
+    () => `Expected ${this.utils.EXPECTED_COLOR('read')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${result.info}` :
+    () => `Expected ${this.utils.EXPECTED_COLOR('read')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${result.info}`;
 
   return {
     message,
-    pass,
+    pass
   };
 }
 
 function toAllowWrite(database, path, value, options) {
-  const { info, allowed } = database
-    .with({ debug: true })
+  const result = database
+    .with({debug: true})
     .write(path, value, options);
 
-  const pass = allowed === true;
-  const message = pass
-    ? () => `Expected ${this.utils.EXPECTED_COLOR('write')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
-    : () => `Expected ${this.utils.EXPECTED_COLOR('write')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+  const pass = result.allowed === true;
+  const message = pass ?
+    () => `Expected ${this.utils.EXPECTED_COLOR('write')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${result.info}` :
+    () => `Expected ${this.utils.EXPECTED_COLOR('write')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${result.info}`;
 
   return {
     message,
-    pass,
+    pass
   };
 }
 
 function toAllowUpdate(database, path, patch, options) {
-  const { info, allowed } = database
-    .with({ debug: true })
+  const result = database
+    .with({debug: true})
     .update(path, patch, options);
 
-  const pass = allowed === true;
-  const message = pass
-    ? () => `Expected ${this.utils.EXPECTED_COLOR('update')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${info}`
-    : () => `Expected ${this.utils.EXPECTED_COLOR('update')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${info}`;
+  const pass = result.allowed === true;
+  const message = pass ?
+    () => `Expected ${this.utils.EXPECTED_COLOR('update')} to be ${this.utils.EXPECTED_COLOR('denied')} but it was ${this.utils.RECEIVED_COLOR('allowed')}\n\n${result.info}` :
+    () => `Expected ${this.utils.EXPECTED_COLOR('update')} to be ${this.utils.EXPECTED_COLOR('allowed')} but it was ${this.utils.RECEIVED_COLOR('denied')}\n\n${result.info}`;
 
   return {
     message,
-    pass,
+    pass
   };
 }
 
 /**
- * Simple wrapper for `targaryen.database()` for conveniently creating a
+ * Expose `targaryen.database()` for conveniently creating a
  * database for a jest test.
+ *
+ * @return {Database}
  */
-function getDatabase(...args) {
-  return targaryen.database(...args);
-}
+const getDatabase = targaryen.database;
 
 /**
  * Simple wrapper for `targaryen.database()` that also enables debug mode for
  * detailed error messages.
+ *
+ * @return {Database}
  */
-function getDebugDatabase(...args) {
-  return targaryen.database(...args).with({ debug: true });
+function getDebugDatabase() {
+  return targaryen.database.apply(this, arguments).with({debug: true});
 }
 
 const jestTargaryen = {
@@ -93,8 +99,8 @@ const jestTargaryen = {
   // NOTE: Exported for convenience only
   getDatabase,
   getDebugDatabase,
-  json: require('firebase-json'),
-  users: targaryen.util.users,
+  json,
+  users: targaryen.util.users
 };
 
 module.exports = jestTargaryen;

--- a/test/jest/.eslintrc.yml
+++ b/test/jest/.eslintrc.yml
@@ -1,0 +1,10 @@
+extends: '../../.eslintrc.yml'
+plugins:
+  - jest
+env:
+  jest/globals: true
+rules:
+  jest/no-disabled-tests: warn
+  jest/no-focused-tests: error
+  jest/no-identical-title: error
+  jest/valid-expect: error

--- a/test/jest/__snapshots__/core.test.js.snap
+++ b/test/jest/__snapshots__/core.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generic matchers toBeAllowed 1`] = `
+"Expected operation to be [32mallowed[39m but it was [31mdenied[39m
+
+Attempt to read /user as null.
+
+/user: read <no rules>
+
+No .read rule allowed the operation.
+read was denied."
+`;
+
+exports[`generic matchers toBeAllowed 2`] = `
+"Expected operation to be [32mdenied[39m but it was [31mallowed[39m
+
+Attempt to write /user/1234 as {\\"uid\\":\\"1234\\"}.
+New Value: \\"{
+  \\"name\\": \\"Anna\\"
+}\\".
+
+/user/1234: write \\"auth.uid === $uid\\"  => true
+  auth.uid === $uid  [=> true]
+  using [
+    $uid = \\"1234\\"
+    auth = {\\"uid\\":\\"1234\\"}
+    auth.uid = \\"1234\\"
+  ]
+
+write was allowed."
+`;

--- a/test/jest/__snapshots__/matchers.test.js.snap
+++ b/test/jest/__snapshots__/matchers.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matchers toAllowRead 1`] = `
+"Expected [32mread[39m to be [32mallowed[39m but it was [31mdenied[39m
+
+Attempt to read /user as null.
+
+/user: read <no rules>
+
+No .read rule allowed the operation.
+read was denied."
+`;
+
+exports[`matchers toAllowRead 2`] = `
+"Expected [32mread[39m to be [32mdenied[39m but it was [31mallowed[39m
+
+Attempt to read /public as null.
+
+/public: read \\"true\\"  => true
+  true  [=> true]
+
+read was allowed."
+`;
+
+exports[`matchers toAllowUpdate 1`] = `
+"Expected [32mupdate[39m to be [32mdenied[39m but it was [31mallowed[39m
+
+Attempt to patch /user/1234 as {\\"uid\\":\\"1234\\"}.
+Patch: \\"{
+  \\"name\\": \\"Anna\\"
+}\\".
+
+/user/1234: write \\"auth.uid === $uid\\"  => true
+  auth.uid === $uid  [=> true]
+  using [
+    $uid = \\"1234\\"
+    auth = {\\"uid\\":\\"1234\\"}
+    auth.uid = \\"1234\\"
+  ]
+
+patch was allowed."
+`;
+
+exports[`matchers toAllowWrite 1`] = `
+"Expected [32mwrite[39m to be [32mdenied[39m but it was [31mallowed[39m
+
+Attempt to write /user/1234 as {\\"uid\\":\\"1234\\"}.
+New Value: \\"{
+  \\"name\\": \\"Anna\\"
+}\\".
+
+/user/1234: write \\"auth.uid === $uid\\"  => true
+  auth.uid === $uid  [=> true]
+  using [
+    $uid = \\"1234\\"
+    auth = {\\"uid\\":\\"1234\\"}
+    auth.uid = \\"1234\\"
+  ]
+
+write was allowed."
+`;

--- a/test/jest/core.test.js
+++ b/test/jest/core.test.js
@@ -1,0 +1,65 @@
+/**
+ * Jest test definition to test targaryen Jest integration.
+ */
+
+'use strict';
+
+const targaryen = require('../../plugins/jest');
+
+expect.extend({
+  toBeAllowed: targaryen.toBeAllowed
+});
+
+test('getDebugDatabase()', () => {
+  const emptyRules = {rules: {}};
+  const database = targaryen.getDebugDatabase(emptyRules, {});
+
+  expect(database.debug).toBe(true);
+});
+
+test('getDatabase()', () => {
+  const emptyRules = {rules: {}};
+  const database = targaryen.getDatabase(emptyRules, {});
+
+  expect(database.debug).toBe(false);
+});
+
+describe('generic matchers', () => {
+  test('toBeAllowed', () => {
+    const rules = {
+      rules: {
+        user: {
+          $uid: {
+            '.read': 'auth.uid !== null',
+            '.write': 'auth.uid === $uid'
+          }
+        }
+      }
+    };
+    const initialData = {};
+
+    // NOTE: Create a database with debug set to true for detailed errors
+    const database = targaryen.getDebugDatabase(rules, initialData);
+
+    expect(() => {
+      expect(database.as(null).read('/user')).not.toBeAllowed();
+    }).not.toThrow();
+
+    expect(() => {
+      expect(database.as(null).read('/user')).toBeAllowed();
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect(database.as({uid: '1234'}).write('/user/1234', {
+        name: 'Anna'
+      })).toBeAllowed();
+    }).not.toThrow();
+
+    expect(() => {
+      expect(database.as({uid: '1234'}).write('/user/1234', {
+        name: 'Anna'
+      })).not.toBeAllowed();
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+

--- a/test/jest/matchers.test.js
+++ b/test/jest/matchers.test.js
@@ -1,0 +1,75 @@
+/**
+ * Jest test definition to test targaryen Jest integration.
+ */
+
+'use strict';
+
+const targaryen = require('../../plugins/jest');
+
+expect.extend({
+  toAllowRead: targaryen.toAllowRead,
+  toAllowUpdate: targaryen.toAllowUpdate,
+  toAllowWrite: targaryen.toAllowWrite
+});
+
+describe('matchers', () => {
+  const rules = {rules: {
+    user: {
+      $uid: {
+        '.read': 'auth.uid !== null',
+        '.write': 'auth.uid === $uid'
+      }
+    },
+    public: {
+      '.read': true
+    }
+  }};
+  const initialData = {};
+  const database = targaryen.getDatabase(rules, initialData);
+
+  test('toAllowRead', () => {
+    expect(() => {
+      expect(database).not.toAllowRead('/user');
+    }).not.toThrow();
+
+    expect(() => {
+      expect(database).toAllowRead('/user');
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect(database).toAllowRead('/public');
+    }).not.toThrow();
+
+    expect(() => {
+      expect(database).not.toAllowRead('/public');
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('toAllowWrite', () => {
+    expect(() => {
+      expect(database.as({uid: '1234'})).toAllowWrite('/user/1234', {
+        name: 'Anna'
+      });
+    }).not.toThrow();
+
+    expect(() => {
+      expect(database.as({uid: '1234'})).not.toAllowWrite('/user/1234', {
+        name: 'Anna'
+      });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('toAllowUpdate', () => {
+    expect(() => {
+      expect(database.as({uid: '1234'})).toAllowUpdate('/user/1234', {
+        name: 'Anna'
+      });
+    }).not.toThrow();
+
+    expect(() => {
+      expect(database.as({uid: '1234'})).not.toAllowUpdate('/user/1234', {
+        name: 'Anna'
+      });
+    }).toThrowErrorMatchingSnapshot();
+  });
+});


### PR DESCRIPTION
Adding jest matchers to conveniently use targaryen with jest.

See https://github.com/goldibex/targaryen/issues/129

Usage:
```javascript
const { getDatabase, toAllowRead, toAllowUpdate, toAllowWrite, json } = require('targaryen/plugins/jest');

expect.extend({
  toAllowRead,
  toAllowUpdate,
  toAllowWrite,
});

const RULES_PATH = 'database.rules.json';
const rules = json.loadSync(RULES_PATH);
const initialData = {};

const database = getDatabase(rules, initialData);

test('basic', () => {
  expect(database.as(null)).not.toAllowRead('/user');
  expect(database.as(null)).toAllowRead('/public');
  expect(database.as({ uid: '1234'})).toAllowWrite('/user/1234', {
    name: 'Anna',
  });
});

```

or using the generic matcher:
```javascript
const { getDebugDatabase, toBeAllowed, json } = require('targaryen/plugins/jest');

expect.extend({
  toBeAllowed,
});

const RULES_PATH = 'database.rules.json';
const rules = json.loadSync(RULES_PATH);
const initialData = {};

// NOTE: Create a database with debug set to true for detailed errors
const database = getDebugDatabase(rules, initialData);

test('generic', () => {
  expect(database.as(null).read('/user')).not.toBeAllowed();
  expect(database.as({ uid: '1234' }).write('/user/1234', {
    name: 'Anna',
  })).toBeAllowed();
});

```