### PR TITLE
Allow .toJSON() function on objects to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
 script:
   - >
-    if [ "$TRAVIS_EVENT_TYPE" == "cron" ] && node --version | grep v6\. ; then
+    if [ "$TRAVIS_EVENT_TYPE" == "cron" ] && node --version | grep --invert-match v4\. ; then
       ./bin/build.sh test:live;
     else
       echo "skipping live tests";

--- a/lib/database/store.js
+++ b/lib/database/store.js
@@ -171,6 +171,10 @@ class DataNode {
       return new DataNode({'.value': value, '.priority': priority});
     }
 
+    if (typeof value === 'object' && typeof value.toJSON === 'function') {
+      return this.from(value.toJSON(), priority, now);
+    }
+
     if (!isObject(value) && !Array.isArray(value)) {
       throw new Error(`Invalid data node type: ${value} (${typeof value})`);
     }

--- a/test/spec/lib/database/store.js
+++ b/test/spec/lib/database/store.js
@@ -62,7 +62,41 @@ describe('store', function() {
     });
   });
 
-  [new Date(), /foo/].forEach(function(v) {
+  it('should let .toJSON() be used as value', function() {
+    class Something {
+      constructor() {
+        Object.defineProperty(this, 'key', {value: 'definedValue', enumberable: false});
+        Object.defineProperty(this, 'key2', {value: 'definedValue'});
+      }
+      toJSON() {
+        return {key: 'val'};
+      }
+    }
+
+    expect(store.create(new Something()).$value()).to.eql({key: 'val'});
+    expect(store.create({v: new Something()}).$value()).to.eql({v: {key: 'val'}});
+  });
+
+  it('should not let classes without .toJSON() be used as value', function() {
+    class Something {
+      constructor() {
+        Object.defineProperty(this, 'key', {value: 'definedValue', enumberable: false});
+        Object.defineProperty(this, 'key2', {value: 'definedValue'});
+      }
+    }
+
+    expect(() => store.create(new Something())).to.throw();
+    expect(() => store.create({v: new Something()})).to.throw();
+  });
+
+  [new Date()].forEach(function(v) {
+    it(`should let ${v.constructor.name} be used as value`, function() {
+      expect(store.create(v).$value()).to.eql(v.toJSON());
+      expect(store.create({v}).$value()).to.eql({v: v.toJSON()});
+    });
+  });
+
+  [/foo/].forEach(function(v) {
     it(`should not let ${v.constructor.name} be used as value`, function() {
       expect(() => store.create(v)).to.throw();
       expect(() => store.create({v})).to.throw();

--- a/test/spec/lib/util.js
+++ b/test/spec/lib/util.js
@@ -8,9 +8,15 @@ describe('util', function() {
 
   describe('setFirebaseData', function() {
 
-    it('should throw on invalid data', function() {
+    it('should not throw on invalid data', function() {
       expect(
         () => util.setFirebaseData(new Date())
+      ).to.not.throw();
+    });
+
+    it('should throw on invalid data', function() {
+      expect(
+        () => util.setFirebaseData(/regex/)
       ).to.throw();
     });
 


### PR DESCRIPTION
Firebase database itself allows toJSON to be used when storing data (I'm guessing through the use of `JSON.stringify`).

I've changed the `.from` method to check for objects and the presence of this method and use it.

Also updated any failing tests and added new ones to cover the change.

Note that this will mean that `new Date()` is now a valid value, stored as `'2018-10-16T10:12:00.060Z'` for example.