### PR TITLE
Fix String.endsWith returning false negatives

### DIFF
--- a/lib/parser/string-methods.js
+++ b/lib/parser/string-methods.js
@@ -32,7 +32,8 @@ module.exports = {
       throw new Error(`${substr} is not a string.`);
     }
 
-    return str.indexOf(substr) + substr.length === str.length;
+    const strSuffix = str.substring(str.length - substr.length, str.length)
+    return strSuffix === substr
   },
 
   replace(str, substr, replacement) {

--- a/test/spec/lib/parser/string-methods.js
+++ b/test/spec/lib/parser/string-methods.js
@@ -36,10 +36,12 @@ describe('stringMethods', function() {
 
     it('returns true if the given string ends with the given substring', function() {
       expect(stringMethods.endsWith('bar', 'ar')).to.be.true();
+      expect(stringMethods.endsWith('arbar', 'ar')).to.be.true();
     });
 
     it('returns false if the given string does not end with the given substring', function() {
       expect(stringMethods.endsWith('bar', 'az')).to.be.false();
+      expect(stringMethods.endsWith('', 'az')).to.be.false();
     });
 
   });


### PR DESCRIPTION
### What does this PR try to solve:
Previous implementation of `String.endsWith(str, substr)` returns false if the the string provided contained more than one instance of the substring.

This PR tries to solve this problem by comparing the suffix of the original string against the substring the user is looking for.

This PR does not use  [`String.endsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) added in ECMA6, so that targaryen is still compatible with node 4

### Testing
Added edge case test to `string-methods.js` test spec


